### PR TITLE
Add harmonic-extension SVD diagnostics and LDL nullity parity tests

### DIFF
--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -6,7 +6,8 @@ export EuclideanSheaf, UnorderedPair, sheaf_laplacian_matrix, sheaf_laplacian_ma
     restricted_laplacian_blocks, sheaf_from_graph, energy_function,
     nearest_global_section, edge_stalk_dimensions, nullspace_ldlt, harmonic_extension,
     ldlt_pseudoinverse_and_null, HarmonicExtensionLDLDiagnostics,
-    harmonic_extension_ldl_diagnostics, zero_sheaf, constant_sheaf, cycle_sheaf
+    HarmonicExtensionSVDDiagnostics, harmonic_extension_ldl_diagnostics,
+    harmonic_extension_svd_diagnostics, zero_sheaf, constant_sheaf, cycle_sheaf
 
 using ArgCheck: @argcheck
 using Graphs
@@ -540,6 +541,8 @@ function nearest_global_section(s::EuclideanSheaf, x; method::Symbol=:cg, verbos
 end
 
 
+_default_ldlt_nullity_threshold(max_abs::Real) = sqrt(eps(Float64)) * max(1.0, Float64(max_abs))
+
 """    nullspace_ldlt(X::AbstractMatrix; tol=nothing) -> Matrix
 
 Compute a basis for the nullspace of the symmetric positive-semidefinite matrix `X`
@@ -548,7 +551,7 @@ with `RowMaximum` pivoting).
 
 The factorisation is ``X = P^\\mathsf{T} L D L^\\mathsf{T} P``.  Columns of `D`
 whose absolute diagonal value is at or below `tol` (default:
-``\\varepsilon_\\text{Float64} \\times \\max(1, \\|D\\|_\\infty)``) identify null
+``\\sqrt{\\varepsilon_\\text{Float64}} \\times \\max(1, \\|D\\|_\\infty)``) identify null
 directions; the corresponding columns of `P^{-1} (L^\\mathsf{T})^{-1}` form the
 returned basis matrix.
 """
@@ -556,7 +559,7 @@ function nullspace_ldlt(X::AbstractMatrix; tol=nothing)
     M = ldlt!(ChordalLDLt(X), RowMaximum())
     D = M.D; L = M.L; P = M.P
     max_abs = maximum(i -> abs(D[i, i]), 1:size(D, 1); init=0.0)
-    threshold = isnothing(tol) ? eps(Float64) * max(1.0, max_abs) : tol
+    threshold = isnothing(tol) ? _default_ldlt_nullity_threshold(max_abs) : tol
     ind = findall(i -> abs(D[i, i]) <= threshold, 1:size(D, 1))
     U = zeros(size(D, 1), length(ind))
     for j in eachindex(ind)
@@ -585,7 +588,7 @@ function ldlt_pseudoinverse_and_null(M, b; tol=nothing)
     D = M.D; Lfac = M.L; P = M.P
     n = size(D, 1)
     max_abs = maximum(i -> abs(D[i, i]), 1:n; init=0.0)
-    threshold = isnothing(tol) ? eps(Float64) * max(1.0, max_abs) : tol
+    threshold = isnothing(tol) ? _default_ldlt_nullity_threshold(max_abs) : tol
 
     null_idx = findall(i -> abs(D[i, i]) <= threshold, 1:n)
 
@@ -643,6 +646,21 @@ struct HarmonicExtensionLDLDiagnostics
     sorted_absolute_pivots::Vector{Float64}
 end
 
+struct HarmonicExtensionSVDDiagnostics
+    boundary_vertices::Vector{Int}
+    interior_vertices::Vector{Int}
+    restricted_size::Tuple{Int,Int}
+    tolerance::Float64
+    nullity_estimate::Int
+    rank_estimate::Int
+    largest_small_singular_value::Float64
+    smallest_positive_singular_value::Float64
+    singular_value_gap::Float64
+    condition_number::Float64
+    positive_condition_number::Float64
+    singular_values::Vector{Float64}
+end
+
 function _show_diag_line(io::IO, label::AbstractString, value)
     println(io, rpad(label, 30), value)
 end
@@ -663,6 +681,22 @@ function Base.show(io::IO, ::MIME"text/plain", diag::HarmonicExtensionLDLDiagnos
     _show_diag_line(io, "smallest positive pivot", _diag_fmt(diag.smallest_positive_pivot))
     _show_diag_line(io, "pivot gap", _diag_fmt(diag.pivot_gap))
     _show_diag_line(io, "sorted |pivots|", diag.sorted_absolute_pivots)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", diag::HarmonicExtensionSVDDiagnostics)
+    println(io, "HarmonicExtensionSVDDiagnostics")
+    _show_diag_line(io, "boundary vertices", diag.boundary_vertices)
+    _show_diag_line(io, "interior vertices", diag.interior_vertices)
+    _show_diag_line(io, "restricted size", diag.restricted_size)
+    _show_diag_line(io, "tolerance", _diag_fmt(diag.tolerance))
+    _show_diag_line(io, "rank estimate", diag.rank_estimate)
+    _show_diag_line(io, "nullity estimate", diag.nullity_estimate)
+    _show_diag_line(io, "largest small singular", _diag_fmt(diag.largest_small_singular_value))
+    _show_diag_line(io, "smallest positive singular", _diag_fmt(diag.smallest_positive_singular_value))
+    _show_diag_line(io, "singular value gap", _diag_fmt(diag.singular_value_gap))
+    _show_diag_line(io, "condition number", _diag_fmt(diag.condition_number))
+    _show_diag_line(io, "positive condition #", _diag_fmt(diag.positive_condition_number))
+    _show_diag_line(io, "singular values", diag.singular_values)
 end
 
 """
@@ -702,7 +736,7 @@ function harmonic_extension_ldl_diagnostics(s::EuclideanSheaf,
     pivots = [M.D[i, i] for i in 1:size(M.D, 1)]
     abs_pivots = abs.(pivots)
     max_abs = maximum(abs_pivots; init=0.0)
-    threshold = isnothing(tol) ? eps(Float64) * max(1.0, max_abs) : Float64(tol)
+    threshold = isnothing(tol) ? _default_ldlt_nullity_threshold(max_abs) : Float64(tol)
     zero_pivots = filter(<=(threshold), abs_pivots)
     positive_pivots = filter(>(threshold), abs_pivots)
 
@@ -722,6 +756,58 @@ function harmonic_extension_ldl_diagnostics(s::EuclideanSheaf,
         pivots,
         abs_pivots,
         sort(abs_pivots),
+    )
+end
+
+"""
+    harmonic_extension_svd_diagnostics(s::EuclideanSheaf,
+                                       boundary::Dict{Int,<:AbstractVector};
+                                       tol=nothing)
+        -> HarmonicExtensionSVDDiagnostics
+
+Compute SVD-based diagnostics for the restricted Laplacian `L_II` used by
+[`harmonic_extension`](@ref) for the boundary data `boundary`.
+
+The interface matches [`harmonic_extension_ldl_diagnostics`](@ref). The return
+value is a `HarmonicExtensionSVDDiagnostics` struct with the same partition
+metadata, plus singular-value-specific diagnostics and a formatted `show`
+method for interactive inspection.
+
+When `L_II` is empty (no interior degrees of freedom), the singular-value arrays
+are empty and the condition numbers are reported as `Inf`.
+"""
+function harmonic_extension_svd_diagnostics(s::EuclideanSheaf,
+                                            boundary::Dict{Int,<:AbstractVector};
+                                            tol=nothing)
+    boundary_verts, interior_verts = _harmonic_extension_partition(s, boundary)
+    L_II, _ = restricted_laplacian_blocks(s, interior_verts, boundary_verts)
+
+    if size(L_II, 1) == 0
+        return HarmonicExtensionSVDDiagnostics(
+            boundary_verts, interior_verts, size(L_II), 0.0, 0, 0,
+            0.0, 0.0, Inf, Inf, Inf, Float64[])
+    end
+
+    singular_values = svdvals(Matrix(L_II))
+    max_sv = maximum(singular_values; init=0.0)
+    threshold = isnothing(tol) ? eps(Float64) * max(1.0, max_sv) : Float64(tol)
+    small_svs = filter(<=(threshold), singular_values)
+    positive_svs = filter(>(threshold), singular_values)
+
+    return HarmonicExtensionSVDDiagnostics(
+        boundary_verts,
+        interior_verts,
+        size(L_II),
+        threshold,
+        length(small_svs),
+        length(positive_svs),
+        isempty(small_svs) ? 0.0 : maximum(small_svs),
+        isempty(positive_svs) ? 0.0 : minimum(positive_svs),
+        isempty(positive_svs) ? Inf : minimum(positive_svs) /
+            max(threshold, isempty(small_svs) ? threshold : maximum(small_svs)),
+        cond(Matrix(L_II)),
+        isempty(positive_svs) ? Inf : maximum(positive_svs) / minimum(positive_svs),
+        singular_values,
     )
 end
 

--- a/src/network_sheaves/TrajectorySheaf.jl
+++ b/src/network_sheaves/TrajectorySheaf.jl
@@ -38,7 +38,8 @@ module TrajectorySheaves
 
 export TrajectorySheaf, build_trajectory_sheaf, colocation_trajectory,
     continuous_to_discrete_zoh, ControlledTrajectorySheaf,
-    feasible_control_trajectory_basis,
+    feasible_control_trajectory_basis, finite_horizon_controllability,
+    expected_feasible_dimension,
     lqr_objective, optimal_control_trajectory, nullspace_trajectory_family
 
 using ArgCheck: @argcheck
@@ -594,6 +595,47 @@ end
 
 function _public_trajectory_block_sizes(ts::ControlledTrajectorySheaf)
     return [fill(ts.state_dim, ts.k + 1); fill(ts.control_dim, ts.k)]
+end
+
+"""
+    finite_horizon_controllability(ts::ControlledTrajectorySheaf{T}) where T
+        -> Matrix{T}
+
+Return the finite-horizon controllability matrix
+
+```math
+\\mathcal{C}_k =
+\begin{bmatrix}
+A_d^{k-1} B_d & A_d^{k-2} B_d & \\cdots & B_d
+\end{bmatrix}
+```
+
+for the `k`-step sampled dynamics stored in `ts`.
+"""
+function finite_horizon_controllability(ts::ControlledTrajectorySheaf{T}) where T
+    return hcat([ts.Ad^(ts.k - t) * ts.Bd for t in 1:ts.k]...)
+end
+
+"""
+    expected_feasible_dimension(ts::ControlledTrajectorySheaf{T};
+                                rtol::Real=1e-10) where T
+        -> Int
+
+Return the expected dimension of the endpoint-preserving feasible trajectory
+family for `ts`, computed as
+
+```math
+k m - \\operatorname{rank}(\\mathcal{C}_k),
+```
+
+where `m` is the control dimension and `\\mathcal{C}_k` is the finite-horizon
+controllability matrix from [`finite_horizon_controllability`](@ref).
+"""
+function expected_feasible_dimension(ts::ControlledTrajectorySheaf{T};
+                                     rtol::Real=1e-10) where T
+    @argcheck rtol > 0 "rtol must be positive, got $rtol"
+    C = finite_horizon_controllability(ts)
+    return ts.k * ts.control_dim - rank(Matrix(C); rtol=rtol)
 end
 
 # ---------------------------------------------------------------------------

--- a/test/network_sheaves/ControlledTrajectoryExamples.jl
+++ b/test/network_sheaves/ControlledTrajectoryExamples.jl
@@ -183,4 +183,86 @@ using BlockArrays
         @test ts.state_dim > 2
     end
 
+    # -----------------------------------------------------------------------
+    # 5. SVD and LDL nullspace dimensionality agreement
+    #    The harmonic-extension diagnostics and the public feasible basis
+    #    should agree with the controllability-based expected dimension.
+    # -----------------------------------------------------------------------
+    @testset "SVD and LDL nullspace dimensionality agree" begin
+        systems = [
+            ("Double integrator",
+             [0.0 1.0; 0.0 0.0],
+             reshape([0.0, 1.0], 2, 1),
+             0.25, 8,
+             EuclideanSheaf{Float64}(fill(2, 1)),
+             [0.0, 0.0],
+             [1.0, 0.0]),
+
+            ("Vehicle platoon",
+             [0.0 1.0 0.0 0.0;
+              0.0 0.0 0.0 0.0;
+              0.0 0.0 0.0 1.0;
+              0.0 0.0 0.0 0.0],
+             [0.0 0.0;
+              1.0 0.0;
+              0.0 0.0;
+              0.0 1.0],
+             0.25, 8,
+             EuclideanSheaf{Float64}([2, 2]),
+             [0.0, 0.0, 2.0, 0.0],
+             [1.0, 0.0, 3.0, 0.0]),
+
+            ("Planar quadrotor",
+             [0.0 0.0 0.0 1.0 0.0 0.0;
+              0.0 0.0 0.0 0.0 1.0 0.0;
+              0.0 0.0 0.0 0.0 0.0 1.0;
+              0.0 0.0 -9.81 0.0 0.0 0.0;
+              0.0 0.0 0.0 0.0 0.0 0.0;
+              0.0 0.0 0.0 0.0 0.0 0.0],
+             [0.0 0.0;
+              0.0 0.0;
+              0.0 0.0;
+              0.0 0.0;
+              2.0 2.0;
+              12.5 -12.5],
+             0.05, 12,
+             EuclideanSheaf{Float64}(fill(6, 1)),
+             zeros(6),
+             [0.5, 0.0, 0.0, 0.0, 0.0, 0.0]),
+
+            ("Mass-spring-damper chain",
+             [0.0 1.0 0.0 0.0;
+              -2.0 -0.4 1.0 0.2;
+              0.0 0.0 0.0 1.0;
+              1.0 0.2 -1.0 -0.2],
+             [0.0 0.0;
+              1.0 0.0;
+              0.0 0.0;
+              0.0 1.0],
+             0.5, 10,
+             EuclideanSheaf{Float64}([2, 2]),
+             [0.0, 0.0, 0.0, 0.0],
+             [0.5, 0.0, 1.0, 0.0]),
+        ]
+
+        for (name, Ac, Bc, h, k, F, x1, xk1) in systems
+            @testset "$name" begin
+                ts = ControlledTrajectorySheaf(F, Ac, Bc, h, k)
+                boundary = Dict{Int,Vector{Float64}}(
+                    1     => convert(Vector{Float64}, x1),
+                    k + 2 => convert(Vector{Float64}, xk1),
+                )
+
+                ldl_diag = harmonic_extension_ldl_diagnostics(ts.sheaf, boundary)
+                svd_diag = harmonic_extension_svd_diagnostics(ts.sheaf, boundary)
+                _, null_basis = feasible_control_trajectory_basis(ts, x1, xk1)
+
+                expected = expected_feasible_dimension(ts)
+                @test ldl_diag.nullity_estimate == svd_diag.nullity_estimate
+                @test ldl_diag.nullity_estimate == expected
+                @test size(null_basis, 2) == expected
+            end
+        end
+    end
+
 end

--- a/test/network_sheaves/ControlledTrajectorySheaf.jl
+++ b/test/network_sheaves/ControlledTrajectorySheaf.jl
@@ -118,6 +118,20 @@ using BlockArrays
     end
 
     # -----------------------------------------------------------------------
+    # 8b. Finite-horizon controllability helpers are part of the public API
+    # -----------------------------------------------------------------------
+    @testset "finite-horizon controllability helpers" begin
+        k  = 3
+        ts = ControlledTrajectorySheaf(F1, Ac_int, Bc_int, h_int, k)
+        C  = finite_horizon_controllability(ts)
+
+        @test size(C) == (1, 3)
+        @test C ≈ [1.0 1.0 1.0]
+        @test expected_feasible_dimension(ts) == 2
+        @test_throws ArgumentError expected_feasible_dimension(ts; rtol=0.0)
+    end
+
+    # -----------------------------------------------------------------------
     # 9. Every null-basis column is a global section of the inner sheaf
     #    (after inverting the public→internal extraction, endpoints = 0)
     # -----------------------------------------------------------------------
@@ -208,6 +222,8 @@ using BlockArrays
         n2 = ts2.state_dim
         @test z_p2[1:n2] ≈ x1_2
         @test z_p2[k*n2+1:(k+1)*n2] ≈ xk1_2
+        @test size(finite_horizon_controllability(ts2)) == (2, 3)
+        @test expected_feasible_dimension(ts2) == 1
     end
 
 end

--- a/test/network_sheaves/HarmonicExtension.jl
+++ b/test/network_sheaves/HarmonicExtension.jl
@@ -101,22 +101,37 @@ using BlockArrays
     # 11. Invalid boundary vertex index throws ArgumentError
     @test_throws ArgumentError harmonic_extension(s, Dict(1 => [0.0], 6 => [4.0]))
 
-    # 12. LDL diagnostics describe the restricted harmonic-extension problem
+    # 12. LDL and SVD diagnostics agree on the restricted harmonic-extension problem
     ldl_diag = harmonic_extension_ldl_diagnostics(s, boundary)
+    svd_diag = harmonic_extension_svd_diagnostics(s, boundary)
     @test ldl_diag isa HarmonicExtensionLDLDiagnostics
+    @test svd_diag isa HarmonicExtensionSVDDiagnostics
     @test ldl_diag.boundary_vertices == [1, 5]
+    @test svd_diag.boundary_vertices == [1, 5]
     @test ldl_diag.interior_vertices == [2, 3, 4]
+    @test svd_diag.interior_vertices == [2, 3, 4]
     @test ldl_diag.restricted_size == (3, 3)
+    @test svd_diag.restricted_size == (3, 3)
     @test ldl_diag.nullity_estimate == 0
+    @test svd_diag.nullity_estimate == 0
     @test ldl_diag.rank_estimate == 3
+    @test svd_diag.rank_estimate == 3
     @test ldl_diag.smallest_positive_pivot > 0.0
+    @test svd_diag.smallest_positive_singular_value > 0.0
     @test isfinite(ldl_diag.pivot_gap)
+    @test isfinite(svd_diag.singular_value_gap)
     @test occursin("HarmonicExtensionLDLDiagnostics", sprint(show, MIME("text/plain"), ldl_diag))
+    @test occursin("HarmonicExtensionSVDDiagnostics", sprint(show, MIME("text/plain"), svd_diag))
+    @test ldl_diag.nullity_estimate == svd_diag.nullity_estimate
 
     # 13. Empty-interior problems return empty diagnostics consistently
     all_boundary_diag_ldl = harmonic_extension_ldl_diagnostics(s, all_bnd)
+    all_boundary_diag_svd = harmonic_extension_svd_diagnostics(s, all_bnd)
     @test all_boundary_diag_ldl.restricted_size == (0, 0)
+    @test all_boundary_diag_svd.restricted_size == (0, 0)
     @test isempty(all_boundary_diag_ldl.pivots)
+    @test isempty(all_boundary_diag_svd.singular_values)
     @test all_boundary_diag_ldl.nullity_estimate == 0
+    @test all_boundary_diag_svd.nullity_estimate == 0
 
 end


### PR DESCRIPTION
Adds SVD-based harmonic-extension diagnostics in src/network_sheaves/EuclideanSheaves.jl so LDL nullity estimates can be checked against an independent SVD-based nullity calculation.

Exports the new SVD diagnostics API from EuclideanSheaves.jl, including HarmonicExtensionSVDDiagnostics and harmonic_extension_svd_diagnostics.

Changes the shared LDL nullity cutoff in src/network_sheaves/EuclideanSheaves.jl from eps(Float64) * max(1.0, max_abs) to sqrt(eps(Float64)) * max(1.0, max_abs).

Applies that looser cutoff in all 3 relevant LDL/nullity paths:
- nullspace_ldlt(...)
- ldlt_pseudoinverse_and_null(...)
- harmonic_extension_ldl_diagnostics(...)

Keeps feasible_control_trajectory_basis on the existing harmonic_extension / LDL solver path in src/network_sheaves/TrajectorySheaf.jl.

Exports finite_horizon_controllability from src/network_sheaves/TrajectorySheaf.jl.

Adds a docstring and implementation for finite_horizon_controllability(ts::ControlledTrajectorySheaf).

Exports expected_feasible_dimension from src/network_sheaves/TrajectorySheaf.jl.

Adds a docstring and implementation for expected_feasible_dimension(ts::ControlledTrajectorySheaf; rtol=1e-10).

Adds LDL-vs-SVD diagnostic parity tests in test/network_sheaves/HarmonicExtension.jl.

Adds unit tests for finite_horizon_controllability and expected_feasible_dimension in test/network_sheaves/ControlledTrajectorySheaf.jl.

Adds a 4-example regression test in test/network_sheaves/ControlledTrajectoryExamples.jl checking that LDL nullity, SVD nullity, and the controllability-based expected feasible dimension agree.

Leaves docs source files, Project.toml, test/Project.toml, and the overall LDL/harmonic-extension solver structure otherwise unchanged.