### PR TITLE
Closed-loop MPC for multi-agent tracking sheaf problems

### DIFF
--- a/docs/literate/control/mpc_target_tracking.jl
+++ b/docs/literate/control/mpc_target_tracking.jl
@@ -376,6 +376,8 @@ for (res, col, wl) in zip([result2_w2, result2_w8, result2_wk],
 end
 p_z
 
+# The W=2 closed-loop animation in the ``y``-``z`` plane:
+
 animate_tracking_xy(result2_w2;
     filename="mpc_scenario2.gif", x_col=IDX_Y, y_col=IDX_Z,
     xlims=(-0.75, 0.75), ylims=(0.1, 2.6), fps=20)

--- a/docs/literate/control/mpc_target_tracking.jl
+++ b/docs/literate/control/mpc_target_tracking.jl
@@ -150,31 +150,12 @@ times = h .* collect(0:k)
 
 R_yz = state_projection_matrix([IDX_Y, IDX_Z], nx, nu)
 R_y  = state_projection_matrix([IDX_Y],         nx, nu)
-R_z  = state_projection_matrix([IDX_Z],         nx, nu)
 
 omega = 2π * 2 / (k * h)
 bt1   = BobbingTarget(-0.3, 1.2,  0.3, omega)
 bt2   = BobbingTarget( 0.3, 1.8, -0.3, omega)
 traj_bt1 = trajectory(bt1, 0:k, h, nx, nu, IDX_Y, IDX_Z, IDX_ZDT)
 traj_bt2 = trajectory(bt2, 0:k, h, nx, nu, IDX_Y, IDX_Z, IDX_ZDT)
-
-function build_boundary(
-    prob,
-    nu::Int;
-    agent_initials::Vector{Vector{Float64}},
-    target_trajs::Vector{Vector{Vector{Float64}}},
-)
-    bnd = Dict{Int,Vector{Float64}}()
-    for (i, x0) in enumerate(agent_initials)
-        bnd[agent_vertex(prob, i, 0)] = vcat(x0, zeros(nu))
-    end
-    for (j, traj) in enumerate(target_trajs)
-        for (t, x) in enumerate(traj)
-            bnd[target_vertex(prob, j, t - 1)] = x
-        end
-    end
-    return bnd
-end
 
 @recipe function f(sr::ScenarioResult)
     layout := (1, 2)
@@ -236,18 +217,22 @@ end
 # example.
 #
 # **When open-loop and MPC agree.**
-# The two solvers agree to machine precision only on feasible problems, where
-# tracking constraints can be satisfied with zero Laplacian energy and the
-# dynamics edges carry zero residual.  On such problems the harmonic section
-# satisfies ``x_{t+1} = A_d x_t + B_d u_t`` exactly at every vertex.
+# The two solvers agree to machine precision only on sheaf-consistent problems,
+# where all tracking, consensus, and dynamics constraints can be satisfied
+# simultaneously.  On such problems the harmonic section has zero Laplacian energy
+# and ``x_{t+1} = A_d x_t + B_d u_t`` holds exactly at every vertex.
 #
 # **When they differ.**
-# Here the problem is infeasible: a sinusoidal altitude cannot be exactly
-# tracked by the quadrotor dynamics, so the harmonic extension is a
-# minimum-energy compromise in which the dynamics edges carry small but nonzero
-# residual.  The open-loop extractor reads the sheaf directly while MPC enforces
-# the true dynamics at every step.  The trajectories are close but not
-# identical — both are valid answers to slightly different questions.
+# The nonzero residual is not caused by the dynamics being infeasible — it arises
+# from a *structural* contradiction between the consensus and tracking edges:
+# `consensus` demands ``R_y x_{a_1}(t) = R_y x_{a_2}(t)`` at every step, while
+# each `track` edge pulls its agent toward a target at a *different* lateral
+# position.  Since the two targets are not at the same ``y`` coordinate, no global
+# section can satisfy both constraints exactly, so the harmonic extension is a
+# minimum-energy compromise over the consensus and tracking edges.  The open-loop
+# extractor reads this compromise directly from the sheaf; MPC additionally
+# enforces the true dynamics at every step, so the two trajectories are close but
+# not identical.
 
 prog1 = @tracking_problem begin
     agent(a1; dynamics=(Ad, Bd), period=h)
@@ -266,8 +251,13 @@ prob1 = lower_tracking_program(prog1, ctx1; tracking_weight=5.0, consensus_weigh
 x0_a1_s1 = [0.0, traj_bt1[1][IDX_Z], 0.0, 0.0, traj_bt1[1][IDX_ZDT], 0.0]
 x0_a2_s1 = [0.0, traj_bt2[1][IDX_Z], 0.0, 0.0, traj_bt2[1][IDX_ZDT], 0.0]
 
-bnd1        = build_boundary(prob1, nu; agent_initials=[x0_a1_s1, x0_a2_s1],
-                             target_trajs=[traj_bt1, traj_bt2])
+bnd1 = Dict{Int,Vector{Float64}}()
+for (i, x0) in enumerate([x0_a1_s1, x0_a2_s1])
+    bnd1[agent_vertex(prob1, i, 0)] = vcat(x0, zeros(nu))
+end
+for (j, traj) in enumerate([traj_bt1, traj_bt2]), (t, x) in enumerate(traj)
+    bnd1[target_vertex(prob1, j, t - 1)] = x
+end
 result1_ol  = run_scenario("open-loop", prob1, bnd1, times;
                            target_trajs=[traj_bt1, traj_bt2], y_col=IDX_Y, z_col=IDX_Z)
 result1_mpc = run_mpc_scenario("MPC (W=k)", prob1, [x0_a1_s1, x0_a2_s1],
@@ -316,14 +306,17 @@ nothing #hide
 #
 # Both agents start at ``(y=0, z=0.35)``, well below and between their targets.
 # Target 1 is at ``y=-0.35, z=1.2`` and Target 2 at ``y=+0.35, z=1.8``; both
-# complete 3.5 vertical bob cycles over the horizon.  There is no consensus
-# edge — agents independently optimize toward their targets in full ``(y,z)``.
+# complete 3.5 vertical bob cycles over the horizon.  A ``y``-consensus edge
+# keeps the agents laterally close while ``(y,z)``-tracking pulls each agent
+# toward its own target at opposite lateral positions — the same structural
+# tension as Scenario 1, which makes window size matter.
 #
 # **Planning horizon controls reactivity.**
 # A shorter window means the controller optimizes over fewer future steps.  At
 # ``W=2`` the controller is essentially greedy, reacting to the current target
-# position without anticipating the next bob.  At ``W=k`` it plans over the
-# full horizon, producing a smoother approach.  Three window sizes are compared.
+# position without anticipating the next bob or the consensus constraint.  At
+# ``W=k`` it plans over the full horizon, finding a smoother compromise between
+# tracking and lateral agreement.  Three window sizes are compared.
 
 omega_fast = 2π * 3.5 / (k * h)
 bt1_s2     = BobbingTarget(-0.35, 1.2,  0.45, omega_fast)
@@ -338,43 +331,29 @@ prog2 = @tracking_problem begin
     target(t2)
     horizon(K)
     times(Tall = 0:K)
+    consensus(c1; agents=(a1,a2), maps=(R_y,R_y), at=Tall)
     track(tr1; agent=a1, target=t1, maps=(R_yz,R_yz), at=Tall)
     track(tr2; agent=a2, target=t2, maps=(R_yz,R_yz), at=Tall)
 end
-ctx2  = Dict{Symbol,Any}(:K => k, :Ad => Ad, :Bd => Bd, :R_yz => R_yz, :h => h)
-prob2 = lower_tracking_program(prog2, ctx2; tracking_weight=5.0).problem
+ctx2  = Dict{Symbol,Any}(:K => k, :Ad => Ad, :Bd => Bd, :R_y => R_y, :R_yz => R_yz, :h => h)
+prob2 = lower_tracking_program(prog2, ctx2; tracking_weight=5.0, consensus_weight=0.8).problem
 
 x0_s2 = [[0.0, 0.35, 0.0, 0.0, 0.0, 0.0],
           [0.0, 0.35, 0.0, 0.0, 0.0, 0.0]]
 
 result2_w2 = run_mpc_scenario("MPC W=2", prob2, x0_s2, [traj_s2_1, traj_s2_2], times;
                               window=2, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
-result2_w8 = run_mpc_scenario("MPC W=8", prob2, x0_s2, [traj_s2_1, traj_s2_2], times;
-                              window=8, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
 result2_wk = run_mpc_scenario("MPC W=k", prob2, x0_s2, [traj_s2_1, traj_s2_2], times;
                               window=k, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
 
 show(stdout, MIME("text/plain"), result2_w2); println()
 show(stdout, MIME("text/plain"), result2_wk); println()
 
-# Altitude z(t) by window size.  Color encodes the window size; solid/dashed
-# lines distinguish the two agents:
-
-p_z = plot(title="Scenario 2 — altitude z(t) by window size",
-           xlabel="t (s)", ylabel="z (m)", legend=:topright,
-           size=(820, 360), grid=true, gridalpha=0.25)
-for (j, traj) in enumerate([traj_s2_1, traj_s2_2])
-    plot!(p_z, times, getindex.(traj, IDX_Z);
-          color=:gray60, lw=1, ls=:dot, alpha=0.6, label=(j == 1 ? "targets" : ""))
-end
-for (res, col, wl) in zip([result2_w2, result2_w8, result2_wk],
-                           [:steelblue, :darkorange, :green], ["W=2", "W=8", "W=k"])
-    for i in 1:2
-        plot!(p_z, times, res.agent_trajs[i][:, IDX_Z];
-              color=col, lw=2, ls=(i == 1 ? :solid : :dash), label="A$i $wl")
-    end
-end
-p_z
+# The null dimension of the window Laplacian grows with planning horizon.
+# At ``W=2`` there are 2 free coordination directions; at ``W=k`` there are 11.
+# Each extra null dimension is an additional degree of freedom in the consensus–tracking
+# compromise that the control cost must resolve.  With `cost=1.0` the cost-optimal
+# representative is unique regardless of null dimension.
 
 # The W=2 closed-loop animation in the ``y``-``z`` plane:
 
@@ -402,7 +381,9 @@ op = tracking_extension_operator(window_problem(prob2, 0, 5); cost=1.0)
 # The cached controller amortizes a single ``L_{II}`` factorization over every
 # full-window step.  Steps near the end of the horizon use shorter unique windows
 # and fall back to the naive path, but for a long horizon these are a small
-# fraction of all steps.
+# fraction of all steps.  At ``W=k`` every step uses a distinct-length window so
+# the cache never reuses its operator, and the two solvers are equivalent (speedup
+# ``\approx 1\times``).
 
 Ws       = [2, 4, 8, 16, 32]
 t_naive  = Float64[]
@@ -438,4 +419,5 @@ for (i, s) in enumerate(speedups)
     annotate!(p_speed[2], i - 0.5, s + maximum(speedups) * 0.05,
               text(@sprintf("%.1f x", s), 9, :center, :steelblue))
 end
+hline!(p_speed[2], [1.0]; color=:gray50, lw=1, ls=:dash, label="")
 p_speed

--- a/docs/literate/control/mpc_target_tracking.jl
+++ b/docs/literate/control/mpc_target_tracking.jl
@@ -1,0 +1,439 @@
+# # Receding-Horizon MPC via a Cached Harmonic Extension
+#
+# This example is the closed-loop counterpart of
+# [Multi-Agent Target Tracking via a Time-Expanded Cellular Sheaf](multi_quadrotor_target_tracking.md).
+# There, a single time-expanded sheaf is solved over the whole horizon and the
+# energy-minimizing global section is read off directly.  Here we build a
+# **model-predictive controller** (MPC) that re-plans at every timestep and show
+# that the time-homogeneity of the tracking sheaf collapses each per-step solve
+# into a single matrix-vector product.
+#
+# **Vehicle model.** Each agent is a planar quadrotor with state
+# ``x = [y,\,z,\,\varphi,\,\dot y,\,\dot z,\,\dot\varphi]^\top \in \mathbb{R}^6``
+# and control ``u = [T_1,T_2]^\top \in \mathbb{R}^2``, linearized about hover and
+# discretized by zero-order hold at period ``h``.
+#
+# **Sheaf structure.** The time-expanded sheaf has one vertex per
+# ``(\text{entity},\, t)`` pair with stalk ``\mathbb{R}^{n_x+n_u}``.
+# Three edge families encode:
+# 1. *Dynamics*: ``x_{t+1} = A_d x_t + B_d u_t`` for each agent and target.
+# 2. *Consensus*: inter-agent agreement on a chosen coordinate subspace.
+# 3. *Tracking*: agent-target alignment in a chosen coordinate subspace.
+#
+# **MPC formulation.** At each timestep ``t`` the controller:
+# 1. Extracts the window sub-problem on ``[t,\, t+W]``.
+# 2. Pins the current agent state and the next ``W`` target samples as *boundary* ``B``.
+# 3. Solves for the free *interior* vertices ``I`` via harmonic extension, finding
+#    the section of minimum Laplacian energy consistent with the boundary:
+#    ```math
+#    x_I = -L_{II}^{+} L_{IB}\, x_B.
+#    ```
+# 4. Applies only the first control ``u_t``, advances the true dynamics, and repeats.
+#
+# When ``L_{II}`` is singular its nullspace ``N = \ker L_{II}`` represents free
+# coordination degrees of freedom.  A control cost ``Q`` selects the cost-optimal
+# representative via the projection
+# ```math
+# M = \bigl(I - N(N^\top Q N)^{+} N^\top Q\bigr)\bigl(-L_{II}^{+} L_{IB}\bigr),
+# ```
+# so that every per-step solve is the single dense matvec ``x_I = M\, x_B``.
+#
+# The problem-construction and solve utilities used below come from
+# `CellularSheaves.ControlSheaves.MultiAgentTracking`.
+#
+# - Problem specification is written with `@tracking_problem` from
+#   `CellularSheaves.ControlSheaves.TrackingDSL`.
+# - The open-loop solver pipeline is `build_boundary -> run_scenario`.
+# - The closed-loop pipeline is `run_mpc_scenario`.
+# - Animations are produced by `animate_tracking_xy`, implemented by the plotting
+#   extension when `Plots` is loaded.
+
+using CellularSheaves
+using CellularSheaves.ControlSheaves.MultiAgentTracking
+using CellularSheaves.ControlSheaves.TrackingDSL
+using CellularSheaves.TrajectorySheaves: continuous_to_discrete_zoh
+using LinearAlgebra
+using Printf
+using Plots
+
+# ## Sliding-Window Structure
+#
+# The diagram below shows one MPC step at ``t = 3`` with window ``W = 4``.
+# Filled vertices are pinned (boundary ``B``) and open vertices are solved
+# (interior ``I``).  Arrows within the window show the dynamics edges
+# ``(A_d, B_d)`` and dashed vertical arrows show the tracking edges.
+
+let
+    k_d   = 10
+    t_now = 3
+    W_d   = 4
+    t_end = t_now + W_d
+    ay    =  0.85
+    ty    = -0.85
+
+    p = plot(size=(860, 230), legend=false, framestyle=:none,
+             xlims=(-0.8, k_d + 0.5), ylims=(-1.45, 1.45),
+             title="MPC window at t = $t_now,  W = $W_d",
+             titlefontsize=11)
+
+    vspan!(p, [t_now - 0.45, t_end + 0.45]; color=:steelblue, alpha=0.07, label="")
+    plot!(p, [0, k_d], [0.0, 0.0]; color=:gray70, lw=1)
+    for t in 0:k_d
+        annotate!(p, t, -0.22, text("$t", 7, :center, :gray55))
+    end
+    for t in t_now:t_end-1
+        for (row, col) in ((ay, :steelblue), (ty, :darkorange))
+            plot!(p, [t + 0.18, t + 0.82], [row, row];
+                  color=col, lw=1.6, arrow=(:closed, 0.3), alpha=0.8)
+        end
+    end
+    for t in t_now:t_end
+        plot!(p, [t, t], [ay - 0.13, ty + 0.13];
+              color=:gray50, lw=1, ls=:dash, alpha=0.6, arrow=(:both, 0.22))
+    end
+    for t in 0:k_d
+        in_w = t_now <= t <= t_end
+        fill_a = (t == t_now) ? :steelblue : (in_w ? :white : :lightgray)
+        scatter!(p, [t], [ay]; color=fill_a,
+                 markerstrokecolor=(in_w ? :steelblue : :gray70),
+                 markerstrokewidth=2, markersize=(t == t_now ? 8 : 6), markershape=:circle)
+        scatter!(p, [t], [ty]; color=(in_w ? :darkorange : :lightgray),
+                 markerstrokecolor=(in_w ? :darkorange : :gray70),
+                 markerstrokewidth=2, markersize=6, markershape=:rect)
+    end
+    annotate!(p, -0.6, ay, text("agent",  8, :right, :steelblue))
+    annotate!(p, -0.6, ty, text("target", 8, :right, :darkorange))
+    annotate!(p, t_now,       ay + 0.32, text("pinned (boundary)", 8, :center, :steelblue))
+    annotate!(p, t_now + 2.5, ay + 0.32, text("free (interior)",   8, :center, :steelblue))
+    annotate!(p, t_now + W_d/2, 0.28,   text("dynamics (A_d, B_d)", 8, :center, :gray40))
+    annotate!(p, t_end + 1.0, (ay+ty)/2, text("tracking\nedge", 7, :center, :gray50))
+    p
+end
+
+# ## Planar Quadrotor Dynamics
+#
+# State: ``x = [y, z, \varphi, \dot y, \dot z, \dot\varphi]``.
+# The linearisation is taken around the hover trim condition.
+# Dynamics, projection matrices, bobbing targets, and helper utilities are set
+# up identically to the open-loop example.
+
+g      = 9.81
+m_veh  = 0.5
+I_quad = 0.01
+ell    = 0.25
+
+Ac = [0.0  0.0   0.0   1.0  0.0  0.0;
+      0.0  0.0   0.0   0.0  1.0  0.0;
+      0.0  0.0   0.0   0.0  0.0  1.0;
+      0.0  0.0  -g     0.0  0.0  0.0;
+      0.0  0.0   0.0   0.0  0.0  0.0;
+      0.0  0.0   0.0   0.0  0.0  0.0]
+
+Bc = [0.0               0.0;
+      0.0               0.0;
+      0.0               0.0;
+      0.0               0.0;
+      1.0 / m_veh       1.0 / m_veh;
+      ell / (2I_quad)  -ell / (2I_quad)]
+
+h = 0.05
+Ad, Bd = continuous_to_discrete_zoh(Ac, Bc, h)
+nx = size(Ad, 1)
+nu = size(Bd, 2)
+
+IDX_Y   = 1
+IDX_Z   = 2
+IDX_ZDT = 5
+
+k     = 40
+times = h .* collect(0:k)
+
+R_yz = state_projection_matrix([IDX_Y, IDX_Z], nx, nu)
+R_y  = state_projection_matrix([IDX_Y],         nx, nu)
+R_z  = state_projection_matrix([IDX_Z],         nx, nu)
+
+omega = 2π * 2 / (k * h)
+bt1   = BobbingTarget(-0.3, 1.2,  0.3, omega)
+bt2   = BobbingTarget( 0.3, 1.8, -0.3, omega)
+traj_bt1 = trajectory(bt1, 0:k, h, nx, nu, IDX_Y, IDX_Z, IDX_ZDT)
+traj_bt2 = trajectory(bt2, 0:k, h, nx, nu, IDX_Y, IDX_Z, IDX_ZDT)
+
+function build_boundary(
+    prob,
+    nu::Int;
+    agent_initials::Vector{Vector{Float64}},
+    target_trajs::Vector{Vector{Vector{Float64}}},
+)
+    bnd = Dict{Int,Vector{Float64}}()
+    for (i, x0) in enumerate(agent_initials)
+        bnd[agent_vertex(prob, i, 0)] = vcat(x0, zeros(nu))
+    end
+    for (j, traj) in enumerate(target_trajs)
+        for (t, x) in enumerate(traj)
+            bnd[target_vertex(prob, j, t - 1)] = x
+        end
+    end
+    return bnd
+end
+
+@recipe function f(sr::ScenarioResult)
+    layout := (1, 2)
+    size := (800, 380)
+    plot_title := "$(sr.label): null dim = $(sr.null_dim),  ||dz|| = $(round(sr.residual; sigdigits=3))"
+    agent_colors  = [:steelblue, :darkorange, :green, :crimson]
+    agent_styles  = [:solid, :dash, :dashdot, :dot]
+    target_colors = [:gray, :black, :darkgreen, :purple]
+    for (i, traj) in enumerate(sr.agent_trajs)
+        @series begin
+            subplot   := 1
+            title     := "y(t)"
+            xlabel    := "t (s)"
+            ylabel    := "y (m)"
+            label     := "A$i"
+            lw        := 2
+            linecolor := agent_colors[i]
+            linestyle := agent_styles[i]
+            sr.times, traj[:, sr.y_col]
+        end
+        @series begin
+            subplot   := 2
+            title     := "z(t)"
+            xlabel    := "t (s)"
+            ylabel    := "z (m)"
+            label     := "A$i"
+            lw        := 2
+            linecolor := agent_colors[i]
+            linestyle := agent_styles[i]
+            sr.times, traj[:, sr.z_col]
+        end
+    end
+    for (j, traj_j) in enumerate(sr.target_trajs)
+        @series begin
+            subplot   := 1
+            label     := "T$j"
+            lw        := 1
+            linecolor := target_colors[j]
+            linestyle := :dot
+            sr.times, getindex.(traj_j, IDX_Y)
+        end
+        @series begin
+            subplot   := 2
+            label     := "T$j"
+            lw        := 1
+            linecolor := target_colors[j]
+            linestyle := :dot
+            sr.times, getindex.(traj_j, IDX_Z)
+        end
+    end
+end
+
+# ## Scenario 1: Bobbing Targets, Open-Loop vs. MPC
+#
+# Two agents track vertically bobbing targets at opposite lateral positions
+# (T1 at ``y=-0.3``, T2 at ``y=+0.3``) with anti-phase bobs.  A ``y``-consensus
+# edge keeps the agents laterally close while ``(y,z)``-tracking pulls each
+# agent toward its own target.  The setup matches Scenario 2 of the open-loop
+# example.
+#
+# **When open-loop and MPC agree.**
+# The two solvers agree to machine precision only on feasible problems, where
+# tracking constraints can be satisfied with zero Laplacian energy and the
+# dynamics edges carry zero residual.  On such problems the harmonic section
+# satisfies ``x_{t+1} = A_d x_t + B_d u_t`` exactly at every vertex.
+#
+# **When they differ.**
+# Here the problem is infeasible: a sinusoidal altitude cannot be exactly
+# tracked by the quadrotor dynamics, so the harmonic extension is a
+# minimum-energy compromise in which the dynamics edges carry small but nonzero
+# residual.  The open-loop extractor reads the sheaf directly while MPC enforces
+# the true dynamics at every step.  The trajectories are close but not
+# identical — both are valid answers to slightly different questions.
+
+prog1 = @tracking_problem begin
+    agent(a1; dynamics=(Ad, Bd), period=h)
+    agent(a2; dynamics=(Ad, Bd), period=h)
+    target(t1)
+    target(t2)
+    horizon(K)
+    times(Tall = 0:K)
+    consensus(c1; agents=(a1,a2), maps=(R_y,R_y), at=Tall)
+    track(tr1; agent=a1, target=t1, maps=(R_yz,R_yz), at=Tall)
+    track(tr2; agent=a2, target=t2, maps=(R_yz,R_yz), at=Tall)
+end
+ctx1  = Dict{Symbol,Any}(:K => k, :Ad => Ad, :Bd => Bd, :R_y => R_y, :R_yz => R_yz, :h => h)
+prob1 = lower_tracking_program(prog1, ctx1; tracking_weight=5.0, consensus_weight=0.8).problem
+
+x0_a1_s1 = [0.0, traj_bt1[1][IDX_Z], 0.0, 0.0, traj_bt1[1][IDX_ZDT], 0.0]
+x0_a2_s1 = [0.0, traj_bt2[1][IDX_Z], 0.0, 0.0, traj_bt2[1][IDX_ZDT], 0.0]
+
+bnd1        = build_boundary(prob1, nu; agent_initials=[x0_a1_s1, x0_a2_s1],
+                             target_trajs=[traj_bt1, traj_bt2])
+result1_ol  = run_scenario("open-loop", prob1, bnd1, times;
+                           target_trajs=[traj_bt1, traj_bt2], y_col=IDX_Y, z_col=IDX_Z)
+result1_mpc = run_mpc_scenario("MPC (W=k)", prob1, [x0_a1_s1, x0_a2_s1],
+                               [traj_bt1, traj_bt2], times;
+                               window=k, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
+
+show(stdout, MIME("text/plain"), result1_ol);  println()
+show(stdout, MIME("text/plain"), result1_mpc); println()
+
+# The side-by-side animation shows open-loop (left) and MPC ``W=k`` (right)
+# in the ``y``-``z`` plane.  Target trails are shown as scatter dots; agent
+# paths accumulate as the simulation advances.
+
+anim1 = @animate for t_idx in 1:k+1
+    p = plot(layout=(1, 2), size=(900, 440), link=:both)
+    for (panel, res, title_str) in (
+            (1, result1_ol,  "Open-loop"),
+            (2, result1_mpc, "MPC (W=k)"))
+        sp = p[panel]
+        plot!(sp; title="$title_str  —  t = $(round(times[t_idx]; digits=2))",
+              xlabel="y (m)", ylabel=(panel == 1 ? "z (m)" : ""),
+              xlims=(-0.65, 0.65), ylims=(0.7, 2.4),
+              legend=:outerright, aspect_ratio=:equal)
+        for (j, traj) in enumerate([traj_bt1, traj_bt2])
+            tx = [v[IDX_Y] for v in traj[1:t_idx]]
+            tz = [v[IDX_Z] for v in traj[1:t_idx]]
+            scatter!(sp, tx, tz; color=[:gray, :black][j],
+                     marker=:star5, markersize=4, alpha=0.6, label="T$j")
+        end
+        for i in 1:2
+            plot!(sp, res.agent_trajs[i][1:t_idx, IDX_Y],
+                      res.agent_trajs[i][1:t_idx, IDX_Z];
+                  seriestype=:path, color=[:steelblue, :darkorange][i],
+                  marker=:circle, markersize=4, alpha=0.6,
+                  linestyle=[:solid, :dash][i], label="A$i")
+        end
+    end
+    p
+end
+gif(anim1, "mpc_side_by_side.gif"; fps=20)
+nothing #hide
+
+# ![Open-loop vs MPC (W=k)](mpc_side_by_side.gif)
+
+# ## Scenario 2: Effect of Planning Horizon
+#
+# Both agents start at ``(y=0, z=0.35)``, well below and between their targets.
+# Target 1 is at ``y=-0.35, z=1.2`` and Target 2 at ``y=+0.35, z=1.8``; both
+# complete 3.5 vertical bob cycles over the horizon.  There is no consensus
+# edge — agents independently optimize toward their targets in full ``(y,z)``.
+#
+# **Planning horizon controls reactivity.**
+# A shorter window means the controller optimizes over fewer future steps.  At
+# ``W=2`` the controller is essentially greedy, reacting to the current target
+# position without anticipating the next bob.  At ``W=k`` it plans over the
+# full horizon, producing a smoother approach.  Three window sizes are compared.
+
+omega_fast = 2π * 3.5 / (k * h)
+bt1_s2     = BobbingTarget(-0.35, 1.2,  0.45, omega_fast)
+bt2_s2     = BobbingTarget( 0.35, 1.8, -0.45, omega_fast)
+traj_s2_1  = trajectory(bt1_s2, 0:k, h, nx, nu, IDX_Y, IDX_Z, IDX_ZDT)
+traj_s2_2  = trajectory(bt2_s2, 0:k, h, nx, nu, IDX_Y, IDX_Z, IDX_ZDT)
+
+prog2 = @tracking_problem begin
+    agent(a1; dynamics=(Ad, Bd), period=h)
+    agent(a2; dynamics=(Ad, Bd), period=h)
+    target(t1)
+    target(t2)
+    horizon(K)
+    times(Tall = 0:K)
+    track(tr1; agent=a1, target=t1, maps=(R_yz,R_yz), at=Tall)
+    track(tr2; agent=a2, target=t2, maps=(R_yz,R_yz), at=Tall)
+end
+ctx2  = Dict{Symbol,Any}(:K => k, :Ad => Ad, :Bd => Bd, :R_yz => R_yz, :h => h)
+prob2 = lower_tracking_program(prog2, ctx2; tracking_weight=5.0).problem
+
+x0_s2 = [[0.0, 0.35, 0.0, 0.0, 0.0, 0.0],
+          [0.0, 0.35, 0.0, 0.0, 0.0, 0.0]]
+
+result2_w2 = run_mpc_scenario("MPC W=2", prob2, x0_s2, [traj_s2_1, traj_s2_2], times;
+                              window=2, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
+result2_w8 = run_mpc_scenario("MPC W=8", prob2, x0_s2, [traj_s2_1, traj_s2_2], times;
+                              window=8, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
+result2_wk = run_mpc_scenario("MPC W=k", prob2, x0_s2, [traj_s2_1, traj_s2_2], times;
+                              window=k, cost=1.0, y_col=IDX_Y, z_col=IDX_Z)
+
+show(stdout, MIME("text/plain"), result2_w2); println()
+show(stdout, MIME("text/plain"), result2_wk); println()
+
+# Altitude z(t) by window size.  Color encodes the window size; solid/dashed
+# lines distinguish the two agents:
+
+p_z = plot(title="Scenario 2 — altitude z(t) by window size",
+           xlabel="t (s)", ylabel="z (m)", legend=:topright,
+           size=(820, 360), grid=true, gridalpha=0.25)
+for (j, traj) in enumerate([traj_s2_1, traj_s2_2])
+    plot!(p_z, times, getindex.(traj, IDX_Z);
+          color=:gray60, lw=1, ls=:dot, alpha=0.6, label=(j == 1 ? "targets" : ""))
+end
+for (res, col, wl) in zip([result2_w2, result2_w8, result2_wk],
+                           [:steelblue, :darkorange, :green], ["W=2", "W=8", "W=k"])
+    for i in 1:2
+        plot!(p_z, times, res.agent_trajs[i][:, IDX_Z];
+              color=col, lw=2, ls=(i == 1 ? :solid : :dash), label="A$i $wl")
+    end
+end
+p_z
+
+animate_tracking_xy(result2_w2;
+    filename="mpc_scenario2.gif", x_col=IDX_Y, y_col=IDX_Z,
+    xlims=(-0.75, 0.75), ylims=(0.1, 2.6), fps=20)
+nothing #hide
+
+# ![Scenario 2 animation (W=2)](mpc_scenario2.gif)
+
+# ## The Cached Extension Operator
+#
+# `tracking_extension_operator` factorizes ``L_{II}`` once for a given window
+# length and folds in the control-cost nullspace projection to produce a dense
+# operator ``M`` such that each MPC step reduces to `M * x_B`.
+
+op = tracking_extension_operator(window_problem(prob2, 0, 5); cost=1.0)
+@printf("boundary DOFs       : %d\n", length(op.boundary))
+@printf("interior DOFs       : %d\n", length(op.interior))
+@printf("null_dim (ker L_II) : %d\n", op.null_dim)
+@printf("M size              : %d x %d\n", size(op.M)...)
+
+# ## Speedup: Cached vs. Naive
+#
+# The cached controller amortizes a single ``L_{II}`` factorization over every
+# full-window step.  Steps near the end of the horizon use shorter unique windows
+# and fall back to the naive path, but for a long horizon these are a small
+# fraction of all steps.
+
+Ws       = [2, 4, 8, 16, 32]
+t_naive  = Float64[]
+t_cached = Float64[]
+for W in Ws
+    run_mpc_scenario("", prob2, x0_s2, [traj_s2_1, traj_s2_2], times; window=W, solver=:naive)
+    run_mpc_scenario("", prob2, x0_s2, [traj_s2_1, traj_s2_2], times; window=W, solver=:cached)
+    tn = minimum(@elapsed(run_mpc_scenario("", prob2, x0_s2, [traj_s2_1, traj_s2_2], times; window=W, solver=:naive))  for _ in 1:7)
+    tc = minimum(@elapsed(run_mpc_scenario("", prob2, x0_s2, [traj_s2_1, traj_s2_2], times; window=W, solver=:cached)) for _ in 1:7)
+    push!(t_naive, tn); push!(t_cached, tc)
+    @printf("W=%-2d  naive %6.2f ms  cached %6.2f ms  speedup %4.1f x\n",
+            W, 1e3tn, 1e3tc, tn/tc)
+end
+
+speedups = t_naive ./ t_cached
+
+p_speed = plot(layout=(1, 2), size=(860, 360),
+               bottom_margin=5Plots.mm, left_margin=5Plots.mm)
+plot!(p_speed[1], Ws, 1e3 .* t_naive;
+      label="naive",  color=:crimson,   lw=2, marker=:circle, ms=5,
+      xlabel="Window size W", ylabel="Time (ms)",
+      title="Solve time (log scale)", yaxis=:log,
+      legend=:bottomright, grid=true, gridalpha=0.25)
+plot!(p_speed[1], Ws, 1e3 .* t_cached;
+      label="cached", color=:steelblue, lw=2, marker=:circle, ms=5)
+bar!(p_speed[2], string.(Ws), speedups;
+     color=:steelblue, legend=false,
+     xlabel="Window size W", ylabel="Speedup (naive / cached)",
+     title="Cached MPC speedup",
+     ylims=(0, maximum(speedups) * 1.3),
+     grid=true, gridalpha=0.25)
+for (i, s) in enumerate(speedups)
+    annotate!(p_speed[2], i - 0.5, s + maximum(speedups) * 0.05,
+              text(@sprintf("%.1f x", s), 9, :center, :steelblue))
+end
+p_speed

--- a/docs/literate/control/mpc_target_tracking.jl
+++ b/docs/literate/control/mpc_target_tracking.jl
@@ -179,7 +179,7 @@ end
 @recipe function f(sr::ScenarioResult)
     layout := (1, 2)
     size := (800, 380)
-    plot_title := "$(sr.label): null dim = $(sr.null_dim),  ||dz|| = $(round(sr.residual; sigdigits=3))"
+    plot_title := "$(sr.label): null dim = $(sr.null_dim),  ||dz|| = $(@sprintf("%.3e", sr.residual))"
     agent_colors  = [:steelblue, :darkorange, :green, :crimson]
     agent_styles  = [:solid, :dash, :dashdot, :dot]
     target_colors = [:gray, :black, :darkgreen, :purple]
@@ -287,7 +287,7 @@ anim1 = @animate for t_idx in 1:k+1
             (1, result1_ol,  "Open-loop"),
             (2, result1_mpc, "MPC (W=k)"))
         sp = p[panel]
-        plot!(sp; title="$title_str  —  t = $(round(times[t_idx]; digits=2))",
+        plot!(sp; title="$title_str  —  t = $(@sprintf("%.3f", times[t_idx]))",
               xlabel="y (m)", ylabel=(panel == 1 ? "z (m)" : ""),
               xlims=(-0.65, 0.65), ylims=(0.7, 2.4),
               legend=:outerright, aspect_ratio=:equal)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,7 +66,9 @@ makedocs(
         "generated/control/controlled_planar_quadrotor.md",
         "generated/control/controlled_mass_spring_damper_chain.md",
         "control/single_integrator_target_tracking.md",
-        "generated/control/multi_quadrotor_target_tracking.md"
+        "generated/control/multi_quadrotor_target_tracking.md",
+        "generated/control/mpc_target_tracking.md"
+
         ],
       "Asynchronous Diffusion"=>Any[
         "generated/asynch/convergence_vs_delay.md",

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -29,7 +29,6 @@ export animate_tracking_xy
 export run_mpc_scenario
 export WindowSolverCache, tracking_extension_operator
 export window_targets, window_problem
-export solve_mpc_step
 
 
 # ---------------------------------------------------------------------------

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -27,7 +27,7 @@ export build_time_expanded_tracking_sheaf
 export generate_reference_trajectory, extract_state_trajectories, extract_target_trajectories, run_scenario
 export animate_tracking_xy
 export run_mpc_scenario
-export TrackingExtension, tracking_extension_operator
+export WindowSolverCache, tracking_extension_operator
 export window_targets, window_problem
 
 
@@ -211,16 +211,17 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    TrackingExtension
+    WindowSolverCache
 
-Precomputed operator for the cost-optimal harmonic extension of a fixed window sheaf.
-Each MPC step reduces to `z[interior] = M * x_B` — a single dense matvec.
+Reusable solver state for the cost-optimal harmonic extension of a fixed window
+sheaf, built once per window length and cached across MPC steps.  Each step then
+reduces to `z[interior] = M * x_B` — a single dense matvec.
 Construct with [`tracking_extension_operator`](@ref).
 
 Fields: `M` (interior×boundary), `boundary`/`interior` (DOF index vectors),
 `stalks`, `laplacian` (for energy), `null_dim`, `window`.
 """
-struct TrackingExtension
+struct WindowSolverCache
     M         :: Matrix{Float64}
     boundary  :: Vector{Int}
     interior  :: Vector{Int}
@@ -231,7 +232,7 @@ struct TrackingExtension
 end
 
 """
-    tracking_extension_operator(window_prob; cost=1.0) -> TrackingExtension
+    tracking_extension_operator(window_prob; cost=1.0) -> WindowSolverCache
 
 Factorize the window Laplacian once and fold in the control-cost nullspace
 projection to produce a dense operator `M` so each MPC step is `M * x_B`.
@@ -257,8 +258,10 @@ function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{N
     sort!(boundary)
     interior = setdiff(1:n, boundary)
 
-    L_II = sparse(L[interior, interior])
-    L_IB = sparse(L[interior, boundary])
+    # L is already sparse, so indexing it with index vectors returns sparse
+    # blocks — no explicit `sparse(...)` needed (asserted by a unit test).
+    L_II = L[interior, interior]
+    L_IB = L[interior, boundary]
     F    = ldlt!(ChordalLDLt(L_II), RowMaximum(); check=false)
     tol  = sqrt(eps(Float64)) * max(1.0, maximum(i -> abs(F.D[i,i]), 1:size(F.D,1); init=0.0))
     _, N = ldlt_pseudoinverse_and_null(F, zeros(length(interior)); tol=tol)
@@ -280,10 +283,10 @@ function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{N
         M = H
     end
 
-    return TrackingExtension(M, boundary, interior, stalks, sparse(L), size(N, 2), W)
+    return WindowSolverCache(M, boundary, interior, stalks, L, size(N, 2), W)
 end
 
-function (op::TrackingExtension)(x_B::AbstractVector)
+function (op::WindowSolverCache)(x_B::AbstractVector)
     @argcheck length(x_B) == length(op.boundary)
     z = zeros(sum(op.stalks))
     z[op.boundary] = x_B
@@ -299,7 +302,7 @@ _uniform_activation(ts, k::Int) = isempty(ts) || sort(unique(ts)) == collect(0:k
 
 Receding-horizon MPC: at each step `t` solves the sheaf QP on `[t, min(t+window,k)]`,
 applies the first control, and advances agent dynamics.  `solver=:cached` reuses a
-[`TrackingExtension`](@ref) for recurring window lengths; falls back to `:naive` on
+[`WindowSolverCache`](@ref) for recurring window lengths; falls back to `:naive` on
 inhomogeneous problems.
 """
 function run_mpc_scenario(
@@ -340,7 +343,7 @@ function run_mpc_scenario(
             window_counts[w] = get(window_counts, w, 0) + 1
         end
     end
-    ops      = Dict{Int,TrackingExtension}()
+    ops      = Dict{Int,WindowSolverCache}()
     nd       = 0
     residual = 0.0
 

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -80,7 +80,7 @@ and 2, matching the planar-quadrotor model convention.
 function run_scenario(
     label::String,
     prob::TrackingProblem,
-    boundary::Union{Dict{Int,Vector{Float64}}, Dict{Int,Float64}},
+    boundary::Dict{Int,Vector{Float64}},
     times::AbstractVector{<:Real};
     target_trajs::Union{Nothing,Vector{Vector{Vector{Float64}}}} = nothing,
     y_col::Int = 1,
@@ -103,7 +103,7 @@ function run_scenario(
     # solve the reduced problem on the nullspace of the harmonic‑extension
     # constraints.  The heavy lifting is delegated to `QuadraticCost` utilities.
     if cost != 0.0
-        Q = build_control_cost_matrix(prob, cost)
+        Q = build_control_cost_matrix(prob, sheaf.vertex_stalks, cost)
         z_opt = solve_quadratic_on_basis(z_harmonic_array, null_basis, Q)
     else
         # No extra cost – just keep the harmonic solution.
@@ -149,35 +149,30 @@ function window_problem(prob::TrackingProblem, t::Int, t_end::Int)
 end
 
 """
-    _assemble_boundary(prob, sheaf, x_agents, target_window) -> Dict{Int,Float64}
+    _assemble_boundary(prob, x_agents, target_window) -> Dict{Int,Vector{Float64}}
 
-Build the DOF-indexed boundary dictionary for `harmonic_extension`:
-- Agent `i`'s state at the window's first timestep is pinned to `x_agents[i]`.
+Build the vertex-indexed boundary dictionary for `harmonic_extension` over the
+MPC-window sheaf (built with `state_only_initial = true`):
+- Agent `i`'s state-only vertex at the window's first timestep is pinned to `x_agents[i]`.
 - Target `j`'s full stalk at each timestep is pinned to `target_window[j][t+1]`.
 
-`sheaf` must be the sheaf built from `prob` (used for stalk offsets).
+Both are full-vertex pins, so this returns a `Dict{Int,Vector{Float64}}`; the
+target stalk dimensions are checked by `harmonic_extension`.
 `target_window` must have `prob.k + 1` samples per target.
 """
 function _assemble_boundary(
     prob::TrackingProblem,
-    sheaf::EuclideanSheaf,
     x_agents::Vector{Vector{Float64}},
     target_window::Vector{Vector{Vector{Float64}}},
 )
-    offsets = [0; cumsum(sheaf.vertex_stalks)]
-    pinned  = Dict{Int,Float64}()
+    pinned = Dict{Int,Vector{Float64}}()
     for i in 1:prob.n_agents
-        va = agent_vertex(prob, i, 0)
-        for c in 1:size(prob.Ad[i], 1)
-            pinned[offsets[va] + c] = x_agents[i][c]
-        end
+        nx_i = size(prob.Ad[i], 1)
+        @argcheck length(x_agents[i]) == nx_i "x_agents[$i] must have length nx=$nx_i, got $(length(x_agents[i]))"
+        pinned[agent_vertex(prob, i, 0)] = x_agents[i]
     end
     for j in 1:prob.n_targets, ts in 0:prob.k
-        vt  = target_vertex(prob, j, ts)
-        val = target_window[j][ts + 1]
-        for c in 1:length(val)
-            pinned[offsets[vt] + c] = val[c]
-        end
+        pinned[target_vertex(prob, j, ts)] = target_window[j][ts + 1]
     end
     return pinned
 end
@@ -185,9 +180,11 @@ end
 """
     _apply_first_control(window_prob, z_opt, stalks) -> Vector{Vector{Float64}}
 
-Extract the control at the window's first timestep from `z_opt` and advance
-each agent's dynamics: `x_{t+1} = Ad_i * x_t + Bd_i * u_t`.
-The agent state `x_t` is read from the section (it was pinned when the window was solved).
+Advance each agent one step using the first decision control of the window.
+In the reindexed window sheaf the initial vertex (`t=0`) is state-only and the
+control `u_1` on vertex `t=1` drives the first transition, so this computes
+`x_{t+1} = Ad_i * x_0 + Bd_i * u_1`.  Both `x_0` (the pinned initial state) and
+`u_1` are read from the section.
 """
 function _apply_first_control(
     window_prob::TrackingProblem,
@@ -196,12 +193,11 @@ function _apply_first_control(
 )
     z_block = BlockArray(z_opt, stalks)
     return map(1:window_prob.n_agents) do i
-        stalk = Array(z_block[Block(agent_vertex(window_prob, i, 0))])
-        nx_i  = size(window_prob.Ad[i], 1)
-        nu_i  = size(window_prob.Bd[i], 2)
-        x_t   = stalk[1:nx_i]
-        u_t   = stalk[nx_i+1 : nx_i+nu_i]
-        window_prob.Ad[i] * x_t + window_prob.Bd[i] * u_t
+        nx_i = size(window_prob.Ad[i], 1)
+        nu_i = size(window_prob.Bd[i], 2)
+        x_0  = Array(z_block[Block(agent_vertex(window_prob, i, 0))])[1:nx_i]
+        u_1  = Array(z_block[Block(agent_vertex(window_prob, i, 1))])[nx_i+1 : nx_i+nu_i]
+        window_prob.Ad[i] * x_0 + window_prob.Bd[i] * u_1
     end
 end
 
@@ -239,7 +235,7 @@ projection to produce a dense operator `M` so each MPC step is `M * x_B`.
 """
 function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{Number,Function}=1.0)
     W       = window_prob.k
-    sheaf   = build_time_expanded_tracking_sheaf(window_prob)
+    sheaf   = build_time_expanded_tracking_sheaf(window_prob; state_only_initial=true)
     L       = sheaf_laplacian_matrix_direct(sheaf)
     stalks  = sheaf.vertex_stalks
     offsets = [0; cumsum(stalks)]
@@ -272,7 +268,7 @@ function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{N
     end
 
     if size(N, 2) > 0 && !(cost isa Number && iszero(cost))
-        Q_II   = Matrix(build_control_cost_matrix(window_prob, cost)[interior, interior])
+        Q_II   = Matrix(build_control_cost_matrix(window_prob, stalks, cost)[interior, interior])
         NtQ_II = N' * Q_II
         Fq     = ldlt!(DenseLDLtPivoted(NtQ_II * N), RowMaximum(); check=false)
         rhs    = NtQ_II * H
@@ -326,6 +322,18 @@ function run_mpc_scenario(
     for j in 1:prob.n_targets
         @argcheck length(target_trajs[j]) >= k + 1 "target_trajs[$j] must have >= k+1=$(k+1) elements, got $(length(target_trajs[j]))"
     end
+    # Per-entity dimension checks (cover both the cached and naive paths, which
+    # otherwise surface mismatches as opaque BoundsErrors deeper in the solve).
+    for i in 1:prob.n_agents
+        nx_i = size(prob.Ad[i], 1)
+        @argcheck length(x0_agents[i]) == nx_i "x0_agents[$i] must have length nx=$nx_i, got $(length(x0_agents[i]))"
+    end
+    for j in 1:prob.n_targets
+        nstalk = size(prob.target_Ad[j], 1) + size(prob.target_Bd[j], 2)
+        for s in 1:(k + 1)
+            @argcheck length(target_trajs[j][s]) == nstalk "target_trajs[$j][$s] must have length $nstalk (target stalk), got $(length(target_trajs[j][s]))"
+        end
+    end
 
     use_cached = solver === :cached &&
                  _uniform_activation(prob.consensus_timesteps, k) &&
@@ -365,12 +373,12 @@ function run_mpc_scenario(
             residual = sqrt(max(0.0, dot(z, op.laplacian * z)))
             x_now    = _apply_first_control(local_prob, z, op.stalks)
         else
-            sheaf    = build_time_expanded_tracking_sheaf(local_prob)
-            boundary = _assemble_boundary(local_prob, sheaf, x_now, local_targets)
+            sheaf    = build_time_expanded_tracking_sheaf(local_prob; state_only_initial=true)
+            boundary = _assemble_boundary(local_prob, x_now, local_targets)
             z, N     = harmonic_extension(sheaf, boundary)
             z_arr    = Array(z)
             if cost != 0.0
-                z_arr = solve_quadratic_on_basis(z_arr, N, build_control_cost_matrix(local_prob, cost))
+                z_arr = solve_quadratic_on_basis(z_arr, N, build_control_cost_matrix(local_prob, sheaf.vertex_stalks, cost))
             end
             L        = sheaf_laplacian_matrix_direct(sheaf)
             t == 0 && (nd = size(N, 2))

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -10,11 +10,14 @@ reference trajectories, solve, and extract results.
 module MultiAgentTracking
 
 using LinearAlgebra
+using SparseArrays
 using BlockArrays
 using ArgCheck
+using CliqueTrees.Multifrontal
 
 using ...NetworkSheaves: EuclideanSheaf, add_sheaf_edge!, harmonic_extension,
-                          sheaf_laplacian_matrix_direct
+                          sheaf_laplacian_matrix_direct,
+                          ldlt_pseudoinverse_and_null, ldlt_pinv_solve
 
 export TrackingEdge, TrackingProblem, BobbingTarget, ScenarioResult
 export trajectory
@@ -23,38 +26,34 @@ export agent_vertex, target_vertex
 export build_time_expanded_tracking_sheaf
 export generate_reference_trajectory, extract_state_trajectories, extract_target_trajectories, run_scenario
 export animate_tracking_xy
+export run_mpc_scenario
+export TrackingExtension, tracking_extension_operator
+export window_targets, window_problem
+
 
 # ---------------------------------------------------------------------------
 # Helper functions
 # ---------------------------------------------------------------------------
 
 """
-    selector_matrix(indices, n)
+    selector_matrix(indices, n) -> Matrix{Float64}
 
-Return the `length(indices) × n` row-selection matrix `S` such that
-`S * v == v[indices]`.  Throws `ArgumentError` if any index is outside `1:n`.
+`length(indices) × n` row-selection matrix `S` such that `S * v == v[indices]`.
 """
 function selector_matrix(indices::AbstractVector{<:Integer}, n::Int)
-    if !(all(i -> i >= 1, indices) && all(i -> i <= n, indices))
-        throw(ArgumentError("All indices must be in 1:$n, got $indices"))
-    end
+    @argcheck all(i -> 1 <= i <= n, indices) "All indices must be in 1:$n, got $indices"
     S = zeros(Float64, length(indices), n)
-    for (row, col) in enumerate(indices)
-        S[row, col] = 1.0
-    end
+    for (row, col) in enumerate(indices); S[row, col] = 1.0; end
     return S
 end
 
 """
-    state_projection_matrix(state_indices, nx, nu)
+    state_projection_matrix(state_indices, nx, nu) -> Matrix{Float64}
 
-Return a `length(state_indices) × (nx + nu)` matrix that selects the given
-state coordinates from an augmented `(nx + nu)`-stalk.
+`length(state_indices) × (nx + nu)` matrix selecting state coordinates from an augmented stalk.
 """
-function state_projection_matrix(state_indices::AbstractVector{<:Integer}, nx::Int, nu::Int)
-    sel = selector_matrix(state_indices, nx)
-    return hcat(sel, zeros(length(state_indices), nu))
-end
+state_projection_matrix(state_indices, nx::Int, nu::Int) =
+    hcat(selector_matrix(state_indices, nx), zeros(length(state_indices), nu))
 
 include("Targets.jl")
 include("TrackingProblems.jl")
@@ -81,42 +80,27 @@ and 2, matching the planar-quadrotor model convention.
 function run_scenario(
     label::String,
     prob::TrackingProblem,
-    boundary::Dict{Int,Vector{Float64}},
+    boundary::Union{Dict{Int,Vector{Float64}}, Dict{Int,Float64}},
     times::AbstractVector{<:Real};
     target_trajs::Union{Nothing,Vector{Vector{Vector{Float64}}}} = nothing,
     y_col::Int = 1,
     z_col::Int = 2,
     cost::Union{Number,Function}=1.0   # (agent, time) -> Q_control matrix or a number
 )
-    # -------------------------------------------------------------------
-    # Build the sheaf and obtain the harmonic‑extension solution
-    # -------------------------------------------------------------------
     sheaf = build_time_expanded_tracking_sheaf(prob)
     z_harmonic, null_basis = harmonic_extension(sheaf, boundary)
     L  = sheaf_laplacian_matrix_direct(sheaf)
     z_harmonic_array = Array(z_harmonic)
     nd = size(null_basis, 2)
 
-    # -------------------------------------------------------------------
-    # Optional quadratic control cost
-    # -------------------------------------------------------------------
-    # Build the global quadratic cost matrix (only on control components) and
-    # solve the reduced problem on the nullspace of the harmonic‑extension
-    # constraints.  The heavy lifting is delegated to `QuadraticCost` utilities.
     if cost != 0.0
         Q = build_control_cost_matrix(prob, cost)
         z_opt = solve_quadratic_on_basis(z_harmonic_array, null_basis, Q)
     else
-        # No extra cost – just keep the harmonic solution.
         z_opt = z_harmonic_array
     end
     residual = sqrt(max(0.0, dot(z_opt, L * z_opt)))
 
-    # -------------------------------------------------------------------
-    # Extract trajectories from the (possibly) optimized solution
-    # -------------------------------------------------------------------
-    # Re‑wrap the vector as a BlockVector so the existing extraction utilities
-    # can operate unchanged.
     z_block = BlockArray(z_opt, sheaf.vertex_stalks)
     trajs = extract_state_trajectories(z_block, prob)
     tt = isnothing(target_trajs) ? extract_target_trajectories(z_block, prob) : target_trajs
@@ -124,12 +108,264 @@ function run_scenario(
 end
 
 """
-    animate_tracking_xy(result; kwargs...)
+    window_targets(target_trajs, t0, t1)
 
-Create a 2D animation for a `ScenarioResult` with agent and target trajectories.
-This method is implemented by the optional plotting extension when `Plots` is
-loaded.
+Return target trajectories sliced to integer timesteps `t0:t1`.
 """
+window_targets(target_trajs, t0::Int, t1::Int) = [traj[t0+1:t1+1] for traj in target_trajs]
+
+"""
+    window_problem(prob, t, t_end) -> TrackingProblem
+
+Extract the sub-problem for timesteps `[t, t_end]` from a full `TrackingProblem`.
+Activation timesteps are shifted to be relative to the window start.
+"""
+function window_problem(prob::TrackingProblem, t::Int, t_end::Int)
+    @argcheck 0 <= t <= t_end <= prob.k "window [$t, $t_end] must be within [0, $(prob.k)]"
+    W = t_end - t
+    return TrackingProblem(
+        prob.n_agents, prob.n_targets, W,
+        prob.Ad, prob.Bd, prob.target_Ad, prob.target_Bd,
+        prob.agent_edges, prob.tracking_edges, prob.consensus_restriction,
+        [ts - t for ts in prob.consensus_timesteps if t <= ts <= t_end],
+        [ts - t for ts in prob.tracking_timesteps  if t <= ts <= t_end],
+        prob.include_target_dynamics, prob.consensus_weight, prob.tracking_weight,
+    )
+end
+
+"""
+    _assemble_boundary(prob, sheaf, x_agents, target_window) -> Dict{Int,Float64}
+
+Build the DOF-indexed boundary dictionary for `harmonic_extension`:
+- Agent `i`'s state at the window's first timestep is pinned to `x_agents[i]`.
+- Target `j`'s full stalk at each timestep is pinned to `target_window[j][t+1]`.
+
+`sheaf` must be the sheaf built from `prob` (used for stalk offsets).
+`target_window` must have `prob.k + 1` samples per target.
+"""
+function _assemble_boundary(
+    prob::TrackingProblem,
+    sheaf::EuclideanSheaf,
+    x_agents::Vector{Vector{Float64}},
+    target_window::Vector{Vector{Vector{Float64}}},
+)
+    offsets = [0; cumsum(sheaf.vertex_stalks)]
+    pinned  = Dict{Int,Float64}()
+    for i in 1:prob.n_agents
+        va = agent_vertex(prob, i, 0)
+        for c in 1:size(prob.Ad[i], 1)
+            pinned[offsets[va] + c] = x_agents[i][c]
+        end
+    end
+    for j in 1:prob.n_targets, ts in 0:prob.k
+        vt  = target_vertex(prob, j, ts)
+        val = target_window[j][ts + 1]
+        for c in 1:length(val)
+            pinned[offsets[vt] + c] = val[c]
+        end
+    end
+    return pinned
+end
+
+"""
+    _apply_first_control(window_prob, z_opt, stalks) -> Vector{Vector{Float64}}
+
+Extract the control at the window's first timestep from `z_opt` and advance
+each agent's dynamics: `x_{t+1} = Ad_i * x_t + Bd_i * u_t`.
+The agent state `x_t` is read from the section (it was pinned when the window was solved).
+"""
+function _apply_first_control(
+    window_prob::TrackingProblem,
+    z_opt::AbstractVector,
+    stalks::Vector{Int},
+)
+    z_block = BlockArray(z_opt, stalks)
+    return map(1:window_prob.n_agents) do i
+        stalk = Array(z_block[Block(agent_vertex(window_prob, i, 0))])
+        nx_i  = size(window_prob.Ad[i], 1)
+        nu_i  = size(window_prob.Bd[i], 2)
+        x_t   = stalk[1:nx_i]
+        u_t   = stalk[nx_i+1 : nx_i+nu_i]
+        window_prob.Ad[i] * x_t + window_prob.Bd[i] * u_t
+    end
+end
+
+
+# ---------------------------------------------------------------------------
+# Cost-optimal harmonic extension operator (cached MPC core)
+# ---------------------------------------------------------------------------
+
+"""
+    TrackingExtension
+
+Precomputed operator for the cost-optimal harmonic extension of a fixed window sheaf.
+Each MPC step reduces to `z[interior] = M * x_B` — a single dense matvec.
+Construct with [`tracking_extension_operator`](@ref).
+
+Fields: `M` (interior×boundary), `boundary`/`interior` (DOF index vectors),
+`stalks`, `laplacian` (for energy), `null_dim`, `window`.
+"""
+struct TrackingExtension
+    M         :: Matrix{Float64}
+    boundary  :: Vector{Int}
+    interior  :: Vector{Int}
+    stalks    :: Vector{Int}
+    laplacian :: SparseMatrixCSC{Float64,Int}
+    null_dim  :: Int
+    window    :: Int
+end
+
+"""
+    tracking_extension_operator(window_prob; cost=1.0) -> TrackingExtension
+
+Factorize the window Laplacian once and fold in the control-cost nullspace
+projection to produce a dense operator `M` so each MPC step is `M * x_B`.
+"""
+function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{Number,Function}=1.0)
+    W       = window_prob.k
+    sheaf   = build_time_expanded_tracking_sheaf(window_prob)
+    L       = sheaf_laplacian_matrix_direct(sheaf)
+    stalks  = sheaf.vertex_stalks
+    offsets = [0; cumsum(stalks)]
+    n       = size(L, 1)
+    nx      = [size(window_prob.Ad[i], 1) for i in 1:window_prob.n_agents]
+
+    boundary = Int[]
+    for i in 1:window_prob.n_agents
+        v = agent_vertex(window_prob, i, 0)
+        for c in 1:nx[i]; push!(boundary, offsets[v] + c); end
+    end
+    for j in 1:window_prob.n_targets, t in 0:W
+        v = target_vertex(window_prob, j, t)
+        for c in 1:stalks[v]; push!(boundary, offsets[v] + c); end
+    end
+    sort!(boundary)
+    interior = setdiff(1:n, boundary)
+
+    L_II = sparse(L[interior, interior])
+    L_IB = sparse(L[interior, boundary])
+    F    = ldlt!(ChordalLDLt(L_II), RowMaximum(); check=false)
+    tol  = sqrt(eps(Float64)) * max(1.0, maximum(i -> abs(F.D[i,i]), 1:size(F.D,1); init=0.0))
+    _, N = ldlt_pseudoinverse_and_null(F, zeros(length(interior)); tol=tol)
+
+    H = Matrix{Float64}(undef, length(interior), length(boundary))
+    for col in axes(L_IB, 2)
+        H[:, col] = ldlt_pinv_solve(F, -Vector(L_IB[:, col]); tol=tol)
+    end
+
+    if size(N, 2) > 0 && !(cost isa Number && iszero(cost))
+        Q_II   = Matrix(build_control_cost_matrix(window_prob, cost)[interior, interior])
+        NtQ_II = N' * Q_II
+        Fq     = ldlt!(DenseLDLtPivoted(NtQ_II * N), RowMaximum(); check=false)
+        rhs    = NtQ_II * H
+        coeff  = similar(rhs)
+        for col in axes(rhs, 2); coeff[:, col] = ldlt_pinv_solve(Fq, rhs[:, col]); end
+        M = H - N * coeff
+    else
+        M = H
+    end
+
+    return TrackingExtension(M, boundary, interior, stalks, sparse(L), size(N, 2), W)
+end
+
+function (op::TrackingExtension)(x_B::AbstractVector)
+    @argcheck length(x_B) == length(op.boundary)
+    z = zeros(sum(op.stalks))
+    z[op.boundary] = x_B
+    z[op.interior] = op.M * x_B
+    return z
+end
+
+_uniform_activation(ts, k::Int) = isempty(ts) || sort(unique(ts)) == collect(0:k)
+
+"""
+    run_mpc_scenario(label, prob, x0_agents, target_trajs, times;
+                     window, y_col=1, z_col=2, cost=1.0, solver=:cached) -> ScenarioResult
+
+Receding-horizon MPC: at each step `t` solves the sheaf QP on `[t, min(t+window,k)]`,
+applies the first control, and advances agent dynamics.  `solver=:cached` reuses a
+[`TrackingExtension`](@ref) for recurring window lengths; falls back to `:naive` on
+inhomogeneous problems.
+"""
+function run_mpc_scenario(
+    label::String,
+    prob::TrackingProblem,
+    x0_agents::Vector{Vector{Float64}},
+    target_trajs::Vector{Vector{Vector{Float64}}},
+    times::AbstractVector{<:Real};
+    window::Int,
+    y_col::Int = 1,
+    z_col::Int = 2,
+    cost::Union{Number,Function} = 1.0,
+    solver::Symbol = :cached,
+)
+    k = prob.k
+    @argcheck window >= 1 "window must be >= 1, got $window"
+    @argcheck solver in (:cached, :naive) "solver must be :cached or :naive, got :$solver"
+    @argcheck length(x0_agents) == prob.n_agents "x0_agents length must equal n_agents=$(prob.n_agents), got $(length(x0_agents))"
+    @argcheck length(target_trajs) == prob.n_targets "target_trajs length must equal n_targets=$(prob.n_targets), got $(length(target_trajs))"
+    @argcheck length(times) == k + 1 "times must have length k+1=$(k+1), got $(length(times))"
+    for j in 1:prob.n_targets
+        @argcheck length(target_trajs[j]) >= k + 1 "target_trajs[$j] must have >= k+1=$(k+1) elements, got $(length(target_trajs[j]))"
+    end
+
+    use_cached = solver === :cached &&
+                 _uniform_activation(prob.consensus_timesteps, k) &&
+                 _uniform_activation(prob.tracking_timesteps, k)
+
+    nx          = [size(prob.Ad[i], 1) for i in 1:prob.n_agents]
+    x_now       = copy.(x0_agents)
+    agent_trajs = [Matrix{Float64}(undef, k+1, nx[i]) for i in 1:prob.n_agents]
+    for i in 1:prob.n_agents; agent_trajs[i][1, :] = x_now[i]; end
+
+    window_counts = Dict{Int,Int}()
+    if use_cached
+        for t in 0:k-1
+            w = min(t + window, k) - t
+            window_counts[w] = get(window_counts, w, 0) + 1
+        end
+    end
+    ops      = Dict{Int,TrackingExtension}()
+    nd       = 0
+    residual = 0.0
+
+    for t in 0:k-1
+        t_end         = min(t + window, k)
+        local_prob    = window_problem(prob, t, t_end)
+        local_targets = window_targets(target_trajs, t, t_end)
+
+        if use_cached && get(window_counts, t_end - t, 0) >= 2
+            op = get!(ops, t_end - t) do; tracking_extension_operator(local_prob; cost=cost); end
+            t == 0 && (nd = op.null_dim)
+            x_B = Vector{Float64}(undef, length(op.boundary))
+            p = 1
+            for i in 1:prob.n_agents, c in 1:nx[i]; x_B[p] = x_now[i][c]; p += 1; end
+            for ts in 0:op.window, j in 1:prob.n_targets
+                for c in eachindex(local_targets[j][ts+1]); x_B[p] = local_targets[j][ts+1][c]; p += 1; end
+            end
+            z        = op(x_B)
+            residual = sqrt(max(0.0, dot(z, op.laplacian * z)))
+            x_now    = _apply_first_control(local_prob, z, op.stalks)
+        else
+            sheaf    = build_time_expanded_tracking_sheaf(local_prob)
+            boundary = _assemble_boundary(local_prob, sheaf, x_now, local_targets)
+            z, N     = harmonic_extension(sheaf, boundary)
+            z_arr    = Array(z)
+            if cost != 0.0
+                z_arr = solve_quadratic_on_basis(z_arr, N, build_control_cost_matrix(local_prob, cost))
+            end
+            L        = sheaf_laplacian_matrix_direct(sheaf)
+            t == 0 && (nd = size(N, 2))
+            residual = sqrt(max(0.0, dot(z_arr, L * z_arr)))
+            x_now    = _apply_first_control(local_prob, z_arr, sheaf.vertex_stalks)
+        end
+
+        for i in 1:prob.n_agents; agent_trajs[i][t+2, :] = x_now[i]; end
+    end
+
+    return ScenarioResult(label, collect(times), agent_trajs, target_trajs, nd, residual, y_col, z_col)
+end
+
 function animate_tracking_xy end
 
 end # module MultiAgentTracking

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -29,6 +29,7 @@ export animate_tracking_xy
 export run_mpc_scenario
 export WindowSolverCache, tracking_extension_operator
 export window_targets, window_problem
+export solve_mpc_step
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +281,7 @@ struct WindowSolverCache
     laplacian :: SparseMatrixCSC{Float64,Int}
     null_dim  :: Int
     window    :: Int
+    scratch   :: Vector{Float64}
 end
 
 """
@@ -306,20 +308,28 @@ function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{N
     _, N = ldlt_pseudoinverse_and_null(F, zeros(length(interior)); tol=tol)
 
     # Harmonic response to every boundary DOF: H = -L_II⁺ L_IB (pinv, many RHS).
-    H = ldlt_pinv_solve(F, L_IB; tol=tol)
+    # `H` is dense `n_I × n_B`, so densifying `L_IB` here costs no extra order of
+    # memory and avoids sparse-column scalar getindex in the per-column solve.
+    H = ldlt_pinv_solve(F, Matrix(L_IB); tol=tol)
     H .*= -1
 
     if size(N, 2) > 0 && !(cost isa Number && iszero(cost))
-        Q_II   = Matrix(build_control_cost_matrix(window_prob, stalks, cost)[interior, interior])
+        # Keep the interior cost block sparse — only the small `nd × n_I` product
+        # `NtQ_II` is materialized dense, never the full `n_I × n_I` matrix.
+        Q_II   = build_control_cost_matrix(window_prob, stalks, cost)[interior, interior]
         NtQ_II = N' * Q_II
-        Fq     = ldlt!(DenseLDLtPivoted(NtQ_II * N), RowMaximum(); check=false)
-        coeff  = ldlt_pinv_solve(Fq, NtQ_II * H)
+        NtQN   = NtQ_II * N
+        Fq     = ldlt!(DenseLDLtPivoted(NtQN), RowMaximum(); check=false)
+        nd_q   = size(N, 2)
+        tol_q  = nd_q * eps(Float64) * max(1.0, maximum(i -> abs(Fq.D[i,i]), 1:nd_q; init=0.0))
+        coeff  = ldlt_pinv_solve(Fq, NtQ_II * H; tol=tol_q)
         M = H - N * coeff
     else
         M = H
     end
 
-    return WindowSolverCache(M, boundary, interior, stalks, L, size(N, 2), W)
+    return WindowSolverCache(M, boundary, interior, stalks, L, size(N, 2), W,
+                             Vector{Float64}(undef, length(interior)))
 end
 
 """
@@ -334,7 +344,8 @@ function LinearAlgebra.mul!(z::AbstractVector, op::WindowSolverCache, x_B::Abstr
     @argcheck length(z) == sum(op.stalks)
     fill!(z, 0.0)
     z[op.boundary] = x_B
-    mul!(view(z, op.interior), op.M, x_B)
+    mul!(op.scratch, op.M, x_B)
+    z[op.interior] = op.scratch
     return z
 end
 

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -87,20 +87,35 @@ function run_scenario(
     z_col::Int = 2,
     cost::Union{Number,Function}=1.0   # (agent, time) -> Q_control matrix or a number
 )
+    # -------------------------------------------------------------------
+    # Build the sheaf and obtain the harmonic‑extension solution
+    # -------------------------------------------------------------------
     sheaf = build_time_expanded_tracking_sheaf(prob)
     z_harmonic, null_basis = harmonic_extension(sheaf, boundary)
     L  = sheaf_laplacian_matrix_direct(sheaf)
     z_harmonic_array = Array(z_harmonic)
     nd = size(null_basis, 2)
 
+    # -------------------------------------------------------------------
+    # Optional quadratic control cost
+    # -------------------------------------------------------------------
+    # Build the global quadratic cost matrix (only on control components) and
+    # solve the reduced problem on the nullspace of the harmonic‑extension
+    # constraints.  The heavy lifting is delegated to `QuadraticCost` utilities.
     if cost != 0.0
         Q = build_control_cost_matrix(prob, cost)
         z_opt = solve_quadratic_on_basis(z_harmonic_array, null_basis, Q)
     else
+        # No extra cost – just keep the harmonic solution.
         z_opt = z_harmonic_array
     end
     residual = sqrt(max(0.0, dot(z_opt, L * z_opt)))
 
+    # -------------------------------------------------------------------
+    # Extract trajectories from the (possibly) optimized solution
+    # -------------------------------------------------------------------
+    # Re‑wrap the vector as a BlockVector so the existing extraction utilities
+    # can operate unchanged.
     z_block = BlockArray(z_opt, sheaf.vertex_stalks)
     trajs = extract_state_trajectories(z_block, prob)
     tt = isnothing(target_trajs) ? extract_target_trajectories(z_block, prob) : target_trajs

--- a/src/ControlSheaves/MultiAgentTracking.jl
+++ b/src/ControlSheaves/MultiAgentTracking.jl
@@ -201,6 +201,61 @@ function _apply_first_control(
     end
 end
 
+# Single source of truth for the window-sheaf boundary ordering.  Visits every
+# pinned block in canonical order — each agent's initial state, then every target
+# stalk by timestep — calling `f(dofs, dest, vals)`: `dofs` are the block's
+# columns in the global Laplacian, `dest` its slice of the packed boundary vector
+# `x_B`, and `vals` the pinned values (`nothing` at operator-build time, when only
+# the DOF layout is needed).  Both `_window_boundary_dofs` and
+# `_fill_boundary_vector!` route through this, so their orderings cannot drift.
+function _foreach_window_boundary(f, prob::TrackingProblem, stalks::AbstractVector{<:Integer};
+                                  x_agents=nothing, targets=nothing)
+    offsets = [0; cumsum(stalks)]
+    pos = 0
+    for i in 1:prob.n_agents
+        v   = agent_vertex(prob, i, 0)
+        nxi = size(prob.Ad[i], 1)
+        vals = isnothing(x_agents) ? nothing : view(x_agents[i], 1:nxi)
+        f(offsets[v]+1 : offsets[v]+nxi, pos+1 : pos+nxi, vals)
+        pos += nxi
+    end
+    for ts in 0:prob.k, j in 1:prob.n_targets
+        v  = target_vertex(prob, j, ts)
+        nd = stalks[v]
+        vals = isnothing(targets) ? nothing : targets[j][ts + 1]
+        f(offsets[v]+1 : offsets[v]+nd, pos+1 : pos+nd, vals)
+        pos += nd
+    end
+    return nothing
+end
+
+# Boundary DOFs of a window sheaf in canonical order (agent initial states, then
+# target stalks by timestep), derived from `_foreach_window_boundary` so it stays
+# aligned with the `x_B` packing by construction.
+function _window_boundary_dofs(prob::TrackingProblem, stalks::AbstractVector{<:Integer})
+    dofs = Int[]
+    _foreach_window_boundary((d, _dest, _vals) -> append!(dofs, d), prob, stalks)
+    return dofs
+end
+
+# Pack the boundary values into `x_B` in the same canonical order, sharing
+# `_foreach_window_boundary` with `_window_boundary_dofs` so the operator's
+# columns and `x_B` stay aligned.
+function _fill_boundary_vector!(x_B, prob::TrackingProblem, stalks, x_agents, targets)
+    _foreach_window_boundary(prob, stalks; x_agents=x_agents, targets=targets) do _dofs, dest, vals
+        copyto!(view(x_B, dest), vals)
+    end
+    return x_B
+end
+
+# Shared tail of both solver paths: window Laplacian energy of the section and the
+# first applied control advancing each agent one step.
+function _finish_step(local_prob::TrackingProblem, z, L, stalks)
+    residual = sqrt(max(0.0, dot(z, L * z)))
+    x_now    = _apply_first_control(local_prob, z, stalks)
+    return x_now, residual
+end
+
 
 # ---------------------------------------------------------------------------
 # Cost-optimal harmonic extension operator (cached MPC core)
@@ -234,25 +289,13 @@ Factorize the window Laplacian once and fold in the control-cost nullspace
 projection to produce a dense operator `M` so each MPC step is `M * x_B`.
 """
 function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{Number,Function}=1.0)
-    W       = window_prob.k
-    sheaf   = build_time_expanded_tracking_sheaf(window_prob; state_only_initial=true)
-    L       = sheaf_laplacian_matrix_direct(sheaf)
-    stalks  = sheaf.vertex_stalks
-    offsets = [0; cumsum(stalks)]
-    n       = size(L, 1)
-    nx      = [size(window_prob.Ad[i], 1) for i in 1:window_prob.n_agents]
+    W      = window_prob.k
+    sheaf  = build_time_expanded_tracking_sheaf(window_prob; state_only_initial=true)
+    L      = sheaf_laplacian_matrix_direct(sheaf)
+    stalks = sheaf.vertex_stalks
 
-    boundary = Int[]
-    for i in 1:window_prob.n_agents
-        v = agent_vertex(window_prob, i, 0)
-        for c in 1:nx[i]; push!(boundary, offsets[v] + c); end
-    end
-    for j in 1:window_prob.n_targets, t in 0:W
-        v = target_vertex(window_prob, j, t)
-        for c in 1:stalks[v]; push!(boundary, offsets[v] + c); end
-    end
-    sort!(boundary)
-    interior = setdiff(1:n, boundary)
+    boundary = _window_boundary_dofs(window_prob, stalks)
+    interior = setdiff(1:size(L, 1), boundary)
 
     # L is already sparse, so indexing it with index vectors returns sparse
     # blocks — no explicit `sparse(...)` needed (asserted by a unit test).
@@ -262,18 +305,15 @@ function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{N
     tol  = sqrt(eps(Float64)) * max(1.0, maximum(i -> abs(F.D[i,i]), 1:size(F.D,1); init=0.0))
     _, N = ldlt_pseudoinverse_and_null(F, zeros(length(interior)); tol=tol)
 
-    H = Matrix{Float64}(undef, length(interior), length(boundary))
-    for col in axes(L_IB, 2)
-        H[:, col] = ldlt_pinv_solve(F, -Vector(L_IB[:, col]); tol=tol)
-    end
+    # Harmonic response to every boundary DOF: H = -L_II⁺ L_IB (pinv, many RHS).
+    H = ldlt_pinv_solve(F, L_IB; tol=tol)
+    H .*= -1
 
     if size(N, 2) > 0 && !(cost isa Number && iszero(cost))
         Q_II   = Matrix(build_control_cost_matrix(window_prob, stalks, cost)[interior, interior])
         NtQ_II = N' * Q_II
         Fq     = ldlt!(DenseLDLtPivoted(NtQ_II * N), RowMaximum(); check=false)
-        rhs    = NtQ_II * H
-        coeff  = similar(rhs)
-        for col in axes(rhs, 2); coeff[:, col] = ldlt_pinv_solve(Fq, rhs[:, col]); end
+        coeff  = ldlt_pinv_solve(Fq, NtQ_II * H)
         M = H - N * coeff
     else
         M = H
@@ -282,13 +322,23 @@ function tracking_extension_operator(window_prob::TrackingProblem; cost::Union{N
     return WindowSolverCache(M, boundary, interior, stalks, L, size(N, 2), W)
 end
 
-function (op::WindowSolverCache)(x_B::AbstractVector)
+"""
+    mul!(z, op::WindowSolverCache, x_B) -> z
+
+Apply the cached operator in place: scatter the boundary values `x_B` and write
+the harmonic interior `M * x_B` directly into `z` (length `sum(op.stalks)`),
+allocating nothing.
+"""
+function LinearAlgebra.mul!(z::AbstractVector, op::WindowSolverCache, x_B::AbstractVector)
     @argcheck length(x_B) == length(op.boundary)
-    z = zeros(sum(op.stalks))
+    @argcheck length(z) == sum(op.stalks)
+    fill!(z, 0.0)
     z[op.boundary] = x_B
-    z[op.interior] = op.M * x_B
+    mul!(view(z, op.interior), op.M, x_B)
     return z
 end
+
+(op::WindowSolverCache)(x_B::AbstractVector) = mul!(zeros(sum(op.stalks)), op, x_B)
 
 _uniform_activation(ts, k::Int) = isempty(ts) || sort(unique(ts)) == collect(0:k)
 
@@ -352,6 +402,8 @@ function run_mpc_scenario(
         end
     end
     ops      = Dict{Int,WindowSolverCache}()
+    xbufs    = Dict{Int,Vector{Float64}}()   # reused boundary vectors, by window length
+    zbufs    = Dict{Int,Vector{Float64}}()   # reused full sections, by window length
     nd       = 0
     residual = 0.0
 
@@ -363,15 +415,11 @@ function run_mpc_scenario(
         if use_cached && get(window_counts, t_end - t, 0) >= 2
             op = get!(ops, t_end - t) do; tracking_extension_operator(local_prob; cost=cost); end
             t == 0 && (nd = op.null_dim)
-            x_B = Vector{Float64}(undef, length(op.boundary))
-            p = 1
-            for i in 1:prob.n_agents, c in 1:nx[i]; x_B[p] = x_now[i][c]; p += 1; end
-            for ts in 0:op.window, j in 1:prob.n_targets
-                for c in eachindex(local_targets[j][ts+1]); x_B[p] = local_targets[j][ts+1][c]; p += 1; end
-            end
-            z        = op(x_B)
-            residual = sqrt(max(0.0, dot(z, op.laplacian * z)))
-            x_now    = _apply_first_control(local_prob, z, op.stalks)
+            x_B = get!(() -> Vector{Float64}(undef, length(op.boundary)), xbufs, t_end - t)
+            _fill_boundary_vector!(x_B, local_prob, op.stalks, x_now, local_targets)
+            z = get!(() -> Vector{Float64}(undef, sum(op.stalks)), zbufs, t_end - t)
+            mul!(z, op, x_B)
+            x_now, residual = _finish_step(local_prob, z, op.laplacian, op.stalks)
         else
             sheaf    = build_time_expanded_tracking_sheaf(local_prob; state_only_initial=true)
             boundary = _assemble_boundary(local_prob, x_now, local_targets)
@@ -380,10 +428,8 @@ function run_mpc_scenario(
             if cost != 0.0
                 z_arr = solve_quadratic_on_basis(z_arr, N, build_control_cost_matrix(local_prob, sheaf.vertex_stalks, cost))
             end
-            L        = sheaf_laplacian_matrix_direct(sheaf)
             t == 0 && (nd = size(N, 2))
-            residual = sqrt(max(0.0, dot(z_arr, L * z_arr)))
-            x_now    = _apply_first_control(local_prob, z_arr, sheaf.vertex_stalks)
+            x_now, residual = _finish_step(local_prob, z_arr, sheaf_laplacian_matrix_direct(sheaf), sheaf.vertex_stalks)
         end
 
         for i in 1:prob.n_agents; agent_trajs[i][t+2, :] = x_now[i]; end

--- a/src/ControlSheaves/QuadraticCosts.jl
+++ b/src/ControlSheaves/QuadraticCosts.jl
@@ -31,66 +31,45 @@ using ....NetworkSheaves: sheaf_laplacian_matrix_direct
 export build_control_cost_matrix, solve_quadratic_on_basis
 
 """
-    build_control_cost_matrix(prob::TrackingProblem, λ::Number) -> SparseMatrixCSC{Float64,Int}
+    build_control_cost_matrix(prob::TrackingProblem, stalks, λ::Number) -> SparseMatrixCSC{Float64,Int}
 
 Construct a global quadratic cost matrix `Q` that penalises the control
 components of each agent with a uniform weight `λ`.  Internally this builds a
 block‑diagonal matrix where each control block is `λ * I(nu)`.
 """
-function build_control_cost_matrix(prob::TrackingProblem, λ::Number=1.0)
-    # Create a simple cost function that returns λ * I(nu) for each agent/time
-    cost_func = (agent_idx::Int, t_step::Int) -> begin
-        nu = size(prob.Bd[agent_idx], 2)
-        return λ * I(nu)
-    end
-    return build_control_cost_matrix(prob, cost_func)
+function build_control_cost_matrix(prob::TrackingProblem, stalks::AbstractVector{<:Integer}, λ::Number=1.0)
+    return build_control_cost_matrix(prob, stalks,
+        (agent_idx::Int, t_step::Int) -> λ * I(size(prob.Bd[agent_idx], 2)))
 end
 
 """
-    build_control_cost_matrix(prob::TrackingProblem, cost_func::Function) -> SparseMatrixCSC{Float64,Int}
+    build_control_cost_matrix(prob::TrackingProblem, stalks, cost_func::Function) -> SparseMatrixCSC{Float64,Int}
 
 Construct a global quadratic cost matrix `Q` using a user‑provided function
 `cost_func(agent_idx, t_step) -> Q_local`.
 
 * `prob` – the `TrackingProblem` describing the agents, dynamics, etc.
+* `stalks` – the sheaf's `vertex_stalks`, giving the DOF layout `Q` is built for.
 * `cost_func` – a function `(agent_idx, t_step) -> Q_local` where
   `Q_local` is a `nu × nu` positive semidefinite matrix for that agent at that timestep.
 
-The returned matrix has size `total_dim × total_dim` where `total_dim` is the
-length of the stacked vector of all stalk variables (states + controls) in the
-time‑expanded sheaf.
+The returned matrix has size `total_dim × total_dim` where `total_dim = sum(stalks)`.
+The control block is read from `stalks` (the trailing `nu` DOFs of each agent
+vertex), so an agent vertex that carries state only — e.g. the `t = 0` vertex of
+the MPC-window sheaf — has no control DOFs and is skipped automatically.
 """
-function build_control_cost_matrix(prob::TrackingProblem, cost_func::Function)
-    # Compute per‑vertex stalk sizes (shared with the scalar version)
-    stalk_sizes = Vector{Int}(undef, (prob.k + 1) * (prob.n_agents + prob.n_targets))
-    for t in 0:prob.k, i in 1:prob.n_agents
-        nx = size(prob.Ad[i], 1)
-        nu = size(prob.Bd[i], 2)
-        stalk_sizes[t * (prob.n_agents + prob.n_targets) + i] = nx + nu
-    end
-    for t in 0:prob.k, j in 1:prob.n_targets
-        nx = size(prob.target_Ad[j], 1)
-        nu = size(prob.target_Bd[j], 2)
-        stalk_sizes[t * (prob.n_agents + prob.n_targets) + prob.n_agents + j] = nx + nu
-    end
-    total_dim = sum(stalk_sizes)
-    Q = spzeros(Float64, total_dim, total_dim)
-
-    function control_range(agent_idx::Int, t_step::Int)
-        v = agent_vertex(prob, agent_idx, t_step)
-        nx = size(prob.Ad[agent_idx], 1)
-        nu = size(prob.Bd[agent_idx], 2)
-        offset = sum(stalk_sizes[1:(v-1)])
-        return (offset + nx + 1) : (offset + nx + nu)
-    end
-
-    for (i, Bd_i) in enumerate(prob.Bd)
-        nu = size(Bd_i, 2)
+function build_control_cost_matrix(prob::TrackingProblem, stalks::AbstractVector{<:Integer}, cost_func::Function)
+    offsets = [0; cumsum(stalks)]
+    Q = spzeros(Float64, last(offsets), last(offsets))
+    for i in 1:prob.n_agents
+        nx = size(prob.Ad[i], 1); nu = size(prob.Bd[i], 2)
         for t_step in 0:prob.k
-            idxs = control_range(i, t_step)
+            v = agent_vertex(prob, i, t_step)
+            stalks[v] == nx + nu || continue   # state-only vertex: no control to penalise
+            rng = (offsets[v] + nx + 1):(offsets[v] + nx + nu)
             Q_local = cost_func(i, t_step)
             @assert size(Q_local) == (nu, nu) "cost_func must return a $(nu)×$(nu) matrix for agent $i at time $t_step"
-            Q[idxs, idxs] = Q_local
+            Q[rng, rng] = Q_local
         end
     end
     return Q

--- a/src/ControlSheaves/QuadraticCosts.jl
+++ b/src/ControlSheaves/QuadraticCosts.jl
@@ -121,11 +121,9 @@ function solve_quadratic_on_basis(
         return copy(point)
     end
     N = basis
-    QN = N' * Q * N
-    rhs = - N' * Q * point
-    # Solve in a least-squares / minimum-norm sense so rank-deficient
-    # reduced Hessians from semidefinite control costs do not throw.
-    α_opt = pinv(QN) * rhs
+    QN = Matrix(N' * Q * N)
+    rhs = -(N' * Q * point)
+    α_opt = svd(QN) \ rhs
     return point + N * α_opt
 end
 

--- a/src/ControlSheaves/QuadraticCosts.jl
+++ b/src/ControlSheaves/QuadraticCosts.jl
@@ -24,9 +24,10 @@ module QuadraticCosts
 
 using SparseArrays
 using LinearAlgebra
+using CliqueTrees.Multifrontal
 using ..MultiAgentTracking: TrackingProblem, agent_vertex, extract_state_trajectories,
     extract_target_trajectories, build_time_expanded_tracking_sheaf
-using ....NetworkSheaves: sheaf_laplacian_matrix_direct
+using ....NetworkSheaves: sheaf_laplacian_matrix_direct, ldlt_pinv_solve
 
 export build_control_cost_matrix, solve_quadratic_on_basis
 
@@ -102,7 +103,11 @@ function solve_quadratic_on_basis(
     N = basis
     QN = Matrix(N' * Q * N)
     rhs = -(N' * Q * point)
-    α_opt = svd(QN) \ rhs
+    # The reduced Hessian N'QN is symmetric PSD and can be rank-deficient when the
+    # control cost is only semidefinite.  Solve via the LDLt pseudoinverse
+    # (min-norm, won't throw on null pivots) rather than a dense SVD.
+    Fq = ldlt!(DenseLDLtPivoted(QN), RowMaximum(); check=false)
+    α_opt = ldlt_pinv_solve(Fq, rhs)
     return point + N * α_opt
 end
 

--- a/src/ControlSheaves/QuadraticCosts.jl
+++ b/src/ControlSheaves/QuadraticCosts.jl
@@ -103,11 +103,10 @@ function solve_quadratic_on_basis(
     N = basis
     QN = Matrix(N' * Q * N)
     rhs = -(N' * Q * point)
-    # The reduced Hessian N'QN is symmetric PSD and can be rank-deficient when the
-    # control cost is only semidefinite.  Solve via the LDLt pseudoinverse
-    # (min-norm, won't throw on null pivots) rather than a dense SVD.
-    Fq = ldlt!(DenseLDLtPivoted(QN), RowMaximum(); check=false)
-    α_opt = ldlt_pinv_solve(Fq, rhs)
+    nd    = size(N, 2)
+    Fq    = ldlt!(DenseLDLtPivoted(QN), RowMaximum(); check=false)
+    tol_q = nd * eps(Float64) * max(1.0, maximum(i -> abs(Fq.D[i,i]), 1:nd; init=0.0))
+    α_opt = ldlt_pinv_solve(Fq, rhs; tol=tol_q)
     return point + N * α_opt
 end
 

--- a/src/ControlSheaves/TrackingProblems.jl
+++ b/src/ControlSheaves/TrackingProblems.jl
@@ -86,8 +86,22 @@ target_vertex(prob::TrackingProblem, j::Int, t::Int) =
 # Sheaf construction
 # ---------------------------------------------------------------------------
 
+# Restriction maps for the agent dynamics edge agent(i,t) ↔ agent(i,t+1).
+# Default:            source [A B], destination [I 0]  ⟹  x_{t+1} = A x_t + B u_t.
+# state_only_initial: controls reindexed so u_{t+1} produces x_{t+1} — source
+#   [A 0] (or just [A] at the state-only t=0 vertex), destination [I −B].
+function _agent_dynamics_maps(Ad, Bd, t::Int, state_only_initial::Bool)
+    nx, nu = size(Ad, 1), size(Bd, 2)
+    if state_only_initial
+        src_map = t == 0 ? Matrix(Ad) : hcat(Matrix(Ad), zeros(nx, nu))
+        return src_map, hcat(Matrix{Float64}(I, nx, nx), -Matrix(Bd))
+    else
+        return hcat(Matrix(Ad), Matrix(Bd)), hcat(Matrix{Float64}(I, nx, nx), zeros(nx, nu))
+    end
+end
+
 """
-    build_time_expanded_tracking_sheaf(prob::TrackingProblem)
+    build_time_expanded_tracking_sheaf(prob::TrackingProblem; state_only_initial=false)
 
 Construct the time-expanded `EuclideanSheaf` from a `TrackingProblem`.
 
@@ -106,8 +120,18 @@ Four edge families are added in order:
 Restriction maps for consensus and tracking edges are pre-scaled by
 `sqrt(consensus_weight)` and `sqrt(tracking_weight)` respectively so that the
 resulting Laplacian is `weight * R' * R`.
+
+When `state_only_initial = true` the initial agent vertices (`t = 0`) carry
+**state only** (no control), and the control is reindexed so that `u_t` produces
+`x_t`: the agent dynamics edge reads `A·x_t` from the source and `x_{t+1} − B·u_{t+1}`
+from the destination, encoding `x_{t+1} = A·x_t + B·u_{t+1}`. Consensus/tracking
+restriction maps at `t = 0` are then truncated to the agent's state columns
+(exact, since those columns multiplied the now-absent control block by zero).
+This makes the initial condition a clean full-vertex pin and is the form used by
+the MPC window solver; the resulting optimal trajectory is identical to the
+default form, which keeps `(x_0, u_0)` on the first vertex.
 """
-function build_time_expanded_tracking_sheaf(prob::TrackingProblem)
+function build_time_expanded_tracking_sheaf(prob::TrackingProblem; state_only_initial::Bool=false)
     @argcheck prob.consensus_weight >= 0 "consensus_weight must be non-negative, got $(prob.consensus_weight)"
     @argcheck prob.tracking_weight  >= 0 "tracking_weight must be non-negative, got $(prob.tracking_weight)"
     @argcheck all(t -> 0 <= t <= prob.k, prob.consensus_timesteps) "all consensus_timesteps must be in 0:$(prob.k), got $(prob.consensus_timesteps)"
@@ -128,11 +152,13 @@ function build_time_expanded_tracking_sheaf(prob::TrackingProblem)
         @argcheck size(prob.target_Bd[j], 1) == size(prob.target_Ad[j], 1) "target_Bd[$j] rows must match target_Ad[$j] rows, got $(size(prob.target_Bd[j],1)) vs $(size(prob.target_Ad[j],1))"
     end
 
-    # Allocate heterogeneous stalk sizes for every vertex (agents + targets)
+    # Allocate heterogeneous stalk sizes for every vertex (agents + targets).
+    # With state_only_initial the t=0 agent vertices hold state only (no control).
     n_per_t = prob.n_agents + prob.n_targets
     stalk_sizes = Vector{Int}(undef, (prob.k + 1) * n_per_t)
     for t in 0:prob.k, i in 1:prob.n_agents
-        stalk_sizes[t * n_per_t + i] = size(prob.Ad[i], 1) + size(prob.Bd[i], 2)
+        nx_i = size(prob.Ad[i], 1); nu_i = size(prob.Bd[i], 2)
+        stalk_sizes[t * n_per_t + i] = (state_only_initial && t == 0) ? nx_i : nx_i + nu_i
     end
     for t in 0:prob.k, j in 1:prob.n_targets
         stalk_sizes[t * n_per_t + prob.n_agents + j] = size(prob.target_Ad[j], 1) + size(prob.target_Bd[j], 2)
@@ -141,14 +167,11 @@ function build_time_expanded_tracking_sheaf(prob::TrackingProblem)
 
     # Agent dynamics edges (per-agent)
     for i in 1:prob.n_agents
-        Ad_i = prob.Ad[i]; Bd_i = prob.Bd[i]
-        nx_i = size(Ad_i, 1); nu_i = size(Bd_i, 2)
-        now_map  = hcat(Matrix(Ad_i), Matrix(Bd_i))
-        next_map = hcat(Matrix{Float64}(I, nx_i, nx_i), zeros(nx_i, nu_i))
         for t in 0:prob.k-1
+            src_map, dst_map = _agent_dynamics_maps(prob.Ad[i], prob.Bd[i], t, state_only_initial)
             add_sheaf_edge!(sheaf,
                 agent_vertex(prob, i, t), agent_vertex(prob, i, t + 1),
-                now_map, next_map)
+                src_map, dst_map)
         end
     end
 
@@ -167,18 +190,23 @@ function build_time_expanded_tracking_sheaf(prob::TrackingProblem)
         end
     end
 
+    # In window mode the t=0 agent stalk is state-only, so its restriction maps
+    # drop the (now absent) control columns; otherwise they are used as given.
+    agent_restr(R, i, t) = (state_only_initial && t == 0) ? R[:, 1:size(prob.Ad[i], 1)] : R
     cscale = sqrt(prob.consensus_weight)
     tscale = sqrt(prob.tracking_weight)
     for t in prob.consensus_timesteps, (i, j) in prob.agent_edges
         add_sheaf_edge!(sheaf,
             agent_vertex(prob, i, t), agent_vertex(prob, j, t),
-            cscale * prob.consensus_restriction, cscale * prob.consensus_restriction)
+            cscale * agent_restr(prob.consensus_restriction, i, t),
+            cscale * agent_restr(prob.consensus_restriction, j, t))
     end
     for t in prob.tracking_timesteps, te in prob.tracking_edges
         add_sheaf_edge!(sheaf,
             agent_vertex(prob, te.agent_index, t),
             target_vertex(prob, te.target_index, t),
-            tscale * te.agent_restriction, tscale * te.target_restriction)
+            tscale * agent_restr(te.agent_restriction, te.agent_index, t),
+            tscale * te.target_restriction)
     end
     return sheaf
 end

--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -544,94 +544,57 @@ end
 
 _default_ldlt_nullity_threshold(max_abs::Real) = sqrt(eps(Float64)) * max(1.0, Float64(max_abs))
 
-function ldiv_diag_pinv!(u, D, b, tol)
-    for i in eachindex(u)
-        d = D[i, i]
-        if abs(d) > tol
-            u[i] = b[i] / d
-        else
-            u[i] = zero(eltype(u))
-        end
+function ldiv_diag_pinv!(u, d::AbstractVector, b, tol)
+    @inbounds for i in eachindex(u)
+        di = d[i]
+        u[i] = di > tol ? b[i] / di : zero(eltype(u))
     end
     return u
 end
 
+ldiv_diag_pinv!(u, D::Diagonal, b, tol) = ldiv_diag_pinv!(u, D.diag, b, tol)
 ldiv_diag_pinv(D, b, tol) = ldiv_diag_pinv!(similar(b), D, b, tol)
 
-"""    ldlt_pinv_solve(F, b; tol=nothing) -> x
 
-Apply the Moore–Penrose pseudoinverse of a symmetric positive-semidefinite
-matrix to the vector `b`, using a precomputed factorization
-``F = P^\\mathsf{T} L D L^\\mathsf{T} P`` (either `ChordalLDLt` or
-`DenseLDLtPivoted` from `CliqueTrees.Multifrontal`).
-
-Null pivots — diagonal entries of `D` with ``|D_{ii}| \\le`` `tol` — are zeroed
-in the diagonal solve, so the result is the minimum-norm solution lying in the
-range of the factorized matrix.  When `tol` is `nothing` it defaults to
-``\\sqrt{\\varepsilon} \\max(1, \\|D\\|_\\infty)``.
-
-Because `F` is reused, this is the per-application kernel for repeated solves
-against the same (possibly singular) matrix — e.g. building a harmonic-extension
-operator column by column.
-"""
-function ldlt_pinv_solve(F, b::AbstractVector; tol=nothing)
-    return ldlt_pinv_solve!(similar(b), F, b, similar(b); tol=tol)
+function ldlt_pinv_solve!(out::AbstractVector, F, b::AbstractVector, w::AbstractVector; tol=nothing)
+    d = F.d
+    perm = F.perm
+    invp = F.invp
+    n = length(d)
+    R = real(eltype(d))
+    τ = tol === nothing ? sqrt(eps(R)) * max(one(R), maximum(abs, d; init=zero(R))) : tol
+    @inbounds for i in 1:n; out[i] = b[perm[i]]; end
+    ldiv!(F.L, out)
+    ldiv_diag_pinv!(w, d, out, τ)       # D⁺ on free directions only
+    ldiv!(F.L', w)
+    @inbounds for i in 1:n; out[i] = w[invp[i]]; end
+    return out
 end
 
-"""    ldlt_pinv_solve!(out, F, b, w; tol=nothing) -> out
-
-In-place form of [`ldlt_pinv_solve`](@ref).  Writes the pseudoinverse solution
-into `out`, using `w` as scratch; both must have length `size(F.D, 1)` and be
-distinct from `b`.  Reusing `out`/`w` across repeated solves against the same
-factorization `F` allocates nothing on the caller's side, which is what makes a
-column-by-column operator build cheap.
-
-For ``F = P^\\mathsf{T} L D L^\\mathsf{T} P`` the result is the closed form
-
-```math
-x = P\\,\\bigl(L^\\mathsf{T} \\backslash\\, D^{+} (L \\backslash (P^\\mathsf{T} b))\\bigr),
-```
-
-read right-to-left: permute `b`, forward solve `L`, apply the diagonal
-pseudoinverse `D⁺` (zeroing null pivots), back solve `Lᵀ`, undo the permutation.
-The permutations are gathers through `F.P.perm` / `F.P.invp`; the triangular
-solves and `D⁺` run in place via `ldiv!` and [`ldiv_diag_pinv!`](@ref).
-"""
-function ldlt_pinv_solve!(out::AbstractVector, F, b::AbstractVector, w::AbstractVector; tol=nothing)
-    D = F.D
-    n = size(D, 1)
-    threshold = isnothing(tol) ?
-        _default_ldlt_nullity_threshold(maximum(i -> abs(D[i, i]), 1:n; init=0.0)) : tol
-    perm = F.P.perm; invp = F.P.invp
-    @inbounds for i in 1:n
-        out[i] = b[perm[i]]                # out = P' \ b  (permute rhs)
-    end
-    ldiv!(F.L, out)                        # forward solve, in place
-    ldiv_diag_pinv!(w, D, out, threshold)  # D⁺ on free directions only
-    ldiv!(F.L', w)                         # back solve, in place
-    @inbounds for i in 1:n
-        out[i] = w[invp[i]]                # out = P \ y  (undo permutation)
-    end
-    return out
+function ldlt_pinv_solve(F, b::AbstractVector; tol=nothing)
+    n = size(F, 1)
+    out = Vector{float(eltype(b))}(undef, n)
+    w = Vector{float(eltype(b))}(undef, n)
+    return ldlt_pinv_solve!(out, F, b, w; tol=tol)
 end
 
 """    ldlt_pinv_solve(F, B::AbstractMatrix; tol=nothing) -> Matrix
 
 Apply the pseudoinverse of the factorized matrix to every column of `B`, i.e.
-return a dense matrix whose `j`-th column is `ldlt_pinv_solve(F, B[:, j])`.  This
-is the multiple-right-hand-side form used to build harmonic-extension operators
-(`X = M⁺ B`); the `out`/`w` scratch buffers are shared across columns.
+return a dense matrix whose `j`-th column is `ldlt_pinv_solve(F, B[:, j])`.
+The `out`/`w` scratch buffers are shared across columns.
 """
 function ldlt_pinv_solve(F, B::AbstractMatrix; tol=nothing)
-    nI = size(B, 1)
-    X      = Matrix{Float64}(undef, nI, size(B, 2))
-    colbuf = Vector{Float64}(undef, nI)
-    wbuf   = Vector{Float64}(undef, nI)
-    outbuf = Vector{Float64}(undef, nI)
-    for j in axes(B, 2)
-        colbuf .= @view B[:, j]
-        ldlt_pinv_solve!(outbuf, F, colbuf, wbuf; tol=tol)
-        @inbounds X[:, j] = outbuf
+    n = size(F, 1)
+    T = float(eltype(B))
+    X = Matrix{T}(undef, n, size(B, 2))
+    col = Vector{T}(undef, n)
+    out = Vector{T}(undef, n)
+    w = Vector{T}(undef, n)
+    @inbounds for j in axes(B, 2)
+        for i in 1:n; col[i] = B[i, j]; end
+        ldlt_pinv_solve!(out, F, col, w; tol=tol)
+        for i in 1:n; X[i, j] = out[i]; end
     end
     return X
 end
@@ -696,7 +659,7 @@ function ldlt_pseudoinverse_and_null(M, b; tol=nothing)
     c = P' \ b                          # permute rhs
     z = Lfac \ c                        # forward solve
     w = zeros(n)
-    ldiv_diag_pinv!(w, D, z, threshold) # D⁺ on free directions only
+    ldiv_diag_pinv!(w, D.diag, z, threshold)
     x_p = P \ (Lfac' \ w)               # back solve + undo permutation
 
     return x_p, null_vecs

--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -5,7 +5,7 @@ module EuclideanSheaves
 export EuclideanSheaf, UnorderedPair, sheaf_laplacian_matrix, sheaf_laplacian_matrix_direct,
     restricted_laplacian_blocks, sheaf_from_graph, energy_function,
     nearest_global_section, edge_stalk_dimensions, nullspace_ldlt, harmonic_extension,
-    ldlt_pseudoinverse_and_null, ldiv_diag_pinv!, ldiv_diag_pinv, ldlt_pinv_solve, HarmonicExtensionLDLDiagnostics,
+    ldlt_pseudoinverse_and_null, ldiv_diag_pinv!, ldiv_diag_pinv, ldlt_pinv_solve, ldlt_pinv_solve!, HarmonicExtensionLDLDiagnostics,
     HarmonicExtensionSVDDiagnostics, harmonic_extension_ldl_diagnostics,
     harmonic_extension_svd_diagnostics, zero_sheaf, constant_sheaf, cycle_sheaf
 
@@ -575,14 +575,44 @@ against the same (possibly singular) matrix — e.g. building a harmonic-extensi
 operator column by column.
 """
 function ldlt_pinv_solve(F, b::AbstractVector; tol=nothing)
+    return ldlt_pinv_solve!(similar(b), F, b, similar(b); tol=tol)
+end
+
+"""    ldlt_pinv_solve!(out, F, b, w; tol=nothing) -> out
+
+In-place form of [`ldlt_pinv_solve`](@ref).  Writes the pseudoinverse solution
+into `out`, using `w` as scratch; both must have length `size(F.D, 1)` and be
+distinct from `b`.  Reusing `out`/`w` across repeated solves against the same
+factorization `F` allocates nothing on the caller's side, which is what makes a
+column-by-column operator build cheap.
+
+For ``F = P^\\mathsf{T} L D L^\\mathsf{T} P`` the result is the closed form
+
+```math
+x = P\\,\\bigl(L^\\mathsf{T} \\backslash\\, D^{+} (L \\backslash (P^\\mathsf{T} b))\\bigr),
+```
+
+read right-to-left: permute `b`, forward solve `L`, apply the diagonal
+pseudoinverse `D⁺` (zeroing null pivots), back solve `Lᵀ`, undo the permutation.
+The permutations are gathers through `F.P.perm` / `F.P.invp`; the triangular
+solves and `D⁺` run in place via `ldiv!` and [`ldiv_diag_pinv!`](@ref).
+"""
+function ldlt_pinv_solve!(out::AbstractVector, F, b::AbstractVector, w::AbstractVector; tol=nothing)
     D = F.D
     n = size(D, 1)
     threshold = isnothing(tol) ?
         _default_ldlt_nullity_threshold(maximum(i -> abs(D[i, i]), 1:n; init=0.0)) : tol
-    c = F.P' \ b
-    z = F.L \ c
-    w = ldiv_diag_pinv(D, z, threshold)
-    return F.P \ (F.L' \ w)
+    perm = F.P.perm; invp = F.P.invp
+    @inbounds for i in 1:n
+        out[i] = b[perm[i]]                # out = P' \ b  (permute rhs)
+    end
+    ldiv!(F.L, out)                        # forward solve, in place
+    ldiv_diag_pinv!(w, D, out, threshold)  # D⁺ on free directions only
+    ldiv!(F.L', w)                         # back solve, in place
+    @inbounds for i in 1:n
+        out[i] = w[invp[i]]                # out = P \ y  (undo permutation)
+    end
+    return out
 end
 
 """    nullspace_ldlt(X::AbstractMatrix; tol=nothing) -> Matrix

--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -641,11 +641,12 @@ function ldlt_pseudoinverse_and_null(M, b; tol=nothing)
     end
     null_vecs = P \ (Lfac' \ U)
 
-    c = P' \ b
-    z = Lfac \ c
+    # Particular solution via pseudoinverse: suppress null directions in D
+    c = P' \ b                          # permute rhs
+    z = Lfac \ c                        # forward solve
     w = zeros(n)
-    ldiv_diag_pinv!(w, D, z, threshold)
-    x_p = P \ (Lfac' \ w)
+    ldiv_diag_pinv!(w, D, z, threshold) # D⁺ on free directions only
+    x_p = P \ (Lfac' \ w)               # back solve + undo permutation
 
     return x_p, null_vecs
 end

--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -615,6 +615,27 @@ function ldlt_pinv_solve!(out::AbstractVector, F, b::AbstractVector, w::Abstract
     return out
 end
 
+"""    ldlt_pinv_solve(F, B::AbstractMatrix; tol=nothing) -> Matrix
+
+Apply the pseudoinverse of the factorized matrix to every column of `B`, i.e.
+return a dense matrix whose `j`-th column is `ldlt_pinv_solve(F, B[:, j])`.  This
+is the multiple-right-hand-side form used to build harmonic-extension operators
+(`X = M⁺ B`); the `out`/`w` scratch buffers are shared across columns.
+"""
+function ldlt_pinv_solve(F, B::AbstractMatrix; tol=nothing)
+    nI = size(B, 1)
+    X      = Matrix{Float64}(undef, nI, size(B, 2))
+    colbuf = Vector{Float64}(undef, nI)
+    wbuf   = Vector{Float64}(undef, nI)
+    outbuf = Vector{Float64}(undef, nI)
+    for j in axes(B, 2)
+        colbuf .= @view B[:, j]
+        ldlt_pinv_solve!(outbuf, F, colbuf, wbuf; tol=tol)
+        @inbounds X[:, j] = outbuf
+    end
+    return X
+end
+
 """    nullspace_ldlt(X::AbstractMatrix; tol=nothing) -> Matrix
 
 Compute a basis for the nullspace of the symmetric positive-semidefinite matrix `X`

--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -914,34 +914,6 @@ function harmonic_extension(s::EuclideanSheaf, boundary::Dict{Int,<:AbstractVect
     return BlockArray(x, s.vertex_stalks), null_basis
 end
 
-# Overload that pins individual stalk components rather than whole vertices.
-# Works directly on the flat Laplacian since the vertex-level helpers above
-# cannot express partial pinning.
-function harmonic_extension(s::EuclideanSheaf, boundary::Dict{Int,Float64})
-    L     = sheaf_laplacian_matrix_direct(s)
-    n     = size(L, 1)
-    B_idx = sort!(collect(keys(boundary)))
-    I_idx = setdiff(1:n, B_idx)
-    x_B   = [boundary[i] for i in B_idx]
-
-    if isempty(B_idx)
-        b = zeros(length(I_idx))
-    else
-        b = -Vector(L[I_idx, B_idx] * x_B)
-    end
-
-    x_interior, null_interior = ldlt_pseudoinverse_and_null(
-        ldlt!(ChordalLDLt(L[I_idx, I_idx]), RowMaximum(); check=false), b)
-
-    x        = zeros(n)
-    x[I_idx] = x_interior
-    x[B_idx] = x_B
-
-    null_basis          = zeros(n, size(null_interior, 2))
-    null_basis[I_idx,:] = null_interior
-
-    return BlockArray(x, s.vertex_stalks), null_basis
-end
 
 
 end # EuclideanSheaves

--- a/src/network_sheaves/EuclideanSheaves.jl
+++ b/src/network_sheaves/EuclideanSheaves.jl
@@ -5,7 +5,7 @@ module EuclideanSheaves
 export EuclideanSheaf, UnorderedPair, sheaf_laplacian_matrix, sheaf_laplacian_matrix_direct,
     restricted_laplacian_blocks, sheaf_from_graph, energy_function,
     nearest_global_section, edge_stalk_dimensions, nullspace_ldlt, harmonic_extension,
-    ldlt_pseudoinverse_and_null, HarmonicExtensionLDLDiagnostics,
+    ldlt_pseudoinverse_and_null, ldiv_diag_pinv!, ldiv_diag_pinv, ldlt_pinv_solve, HarmonicExtensionLDLDiagnostics,
     HarmonicExtensionSVDDiagnostics, harmonic_extension_ldl_diagnostics,
     harmonic_extension_svd_diagnostics, zero_sheaf, constant_sheaf, cycle_sheaf
 
@@ -544,6 +544,47 @@ end
 
 _default_ldlt_nullity_threshold(max_abs::Real) = sqrt(eps(Float64)) * max(1.0, Float64(max_abs))
 
+function ldiv_diag_pinv!(u, D, b, tol)
+    for i in eachindex(u)
+        d = D[i, i]
+        if abs(d) > tol
+            u[i] = b[i] / d
+        else
+            u[i] = zero(eltype(u))
+        end
+    end
+    return u
+end
+
+ldiv_diag_pinv(D, b, tol) = ldiv_diag_pinv!(similar(b), D, b, tol)
+
+"""    ldlt_pinv_solve(F, b; tol=nothing) -> x
+
+Apply the Moore–Penrose pseudoinverse of a symmetric positive-semidefinite
+matrix to the vector `b`, using a precomputed factorization
+``F = P^\\mathsf{T} L D L^\\mathsf{T} P`` (either `ChordalLDLt` or
+`DenseLDLtPivoted` from `CliqueTrees.Multifrontal`).
+
+Null pivots — diagonal entries of `D` with ``|D_{ii}| \\le`` `tol` — are zeroed
+in the diagonal solve, so the result is the minimum-norm solution lying in the
+range of the factorized matrix.  When `tol` is `nothing` it defaults to
+``\\sqrt{\\varepsilon} \\max(1, \\|D\\|_\\infty)``.
+
+Because `F` is reused, this is the per-application kernel for repeated solves
+against the same (possibly singular) matrix — e.g. building a harmonic-extension
+operator column by column.
+"""
+function ldlt_pinv_solve(F, b::AbstractVector; tol=nothing)
+    D = F.D
+    n = size(D, 1)
+    threshold = isnothing(tol) ?
+        _default_ldlt_nullity_threshold(maximum(i -> abs(D[i, i]), 1:n; init=0.0)) : tol
+    c = F.P' \ b
+    z = F.L \ c
+    w = ldiv_diag_pinv(D, z, threshold)
+    return F.P \ (F.L' \ w)
+end
+
 """    nullspace_ldlt(X::AbstractMatrix; tol=nothing) -> Matrix
 
 Compute a basis for the nullspace of the symmetric positive-semidefinite matrix `X`
@@ -557,7 +598,7 @@ directions; the corresponding columns of `P^{-1} (L^\\mathsf{T})^{-1}` form the
 returned basis matrix.
 """
 function nullspace_ldlt(X::AbstractMatrix; tol=nothing)
-    M = ldlt!(ChordalLDLt(X), RowMaximum())
+    M = ldlt!(ChordalLDLt(X), RowMaximum(); check=false)
     D = M.D; L = M.L; P = M.P
     max_abs = maximum(i -> abs(D[i, i]), 1:size(D, 1); init=0.0)
     threshold = isnothing(tol) ? _default_ldlt_nullity_threshold(max_abs) : tol
@@ -600,14 +641,11 @@ function ldlt_pseudoinverse_and_null(M, b; tol=nothing)
     end
     null_vecs = P \ (Lfac' \ U)
 
-    # Particular solution via pseudoinverse: suppress null directions in D
-    c = P' \ b          # permute rhs
-    z = Lfac \ c        # forward solve
+    c = P' \ b
+    z = Lfac \ c
     w = zeros(n)
-    for i in setdiff(1:n, null_idx)
-        w[i] = z[i] / D[i, i]  # D⁺ on free directions only
-    end
-    x_p = P \ (Lfac' \ w)  # back solve + undo permutation
+    ldiv_diag_pinv!(w, D, z, threshold)
+    x_p = P \ (Lfac' \ w)
 
     return x_p, null_vecs
 end
@@ -733,7 +771,7 @@ function harmonic_extension_ldl_diagnostics(s::EuclideanSheaf,
             0.0, 0.0, 0.0, 0.0, Inf, Float64[], Float64[], Float64[])
     end
 
-    M = ldlt!(ChordalLDLt(L_II), RowMaximum())
+    M = ldlt!(ChordalLDLt(L_II), RowMaximum(); check=false)
     pivots = [M.D[i, i] for i in 1:size(M.D, 1)]
     abs_pivots = abs.(pivots)
     max_abs = maximum(abs_pivots; init=0.0)
@@ -861,7 +899,7 @@ function harmonic_extension(s::EuclideanSheaf, boundary::Dict{Int,<:AbstractVect
     end
 
     x_interior, null_interior = ldlt_pseudoinverse_and_null(
-        ldlt!(ChordalLDLt(L_II), RowMaximum()), b)
+        ldlt!(ChordalLDLt(L_II), RowMaximum(); check=false), b)
 
     x        = zeros(n_total)
     x[I_idx] = x_interior
@@ -870,6 +908,35 @@ function harmonic_extension(s::EuclideanSheaf, boundary::Dict{Int,<:AbstractVect
     end
 
     null_basis          = zeros(n_total, size(null_interior, 2))
+    null_basis[I_idx,:] = null_interior
+
+    return BlockArray(x, s.vertex_stalks), null_basis
+end
+
+# Overload that pins individual stalk components rather than whole vertices.
+# Works directly on the flat Laplacian since the vertex-level helpers above
+# cannot express partial pinning.
+function harmonic_extension(s::EuclideanSheaf, boundary::Dict{Int,Float64})
+    L     = sheaf_laplacian_matrix_direct(s)
+    n     = size(L, 1)
+    B_idx = sort!(collect(keys(boundary)))
+    I_idx = setdiff(1:n, B_idx)
+    x_B   = [boundary[i] for i in B_idx]
+
+    if isempty(B_idx)
+        b = zeros(length(I_idx))
+    else
+        b = -Vector(L[I_idx, B_idx] * x_B)
+    end
+
+    x_interior, null_interior = ldlt_pseudoinverse_and_null(
+        ldlt!(ChordalLDLt(L[I_idx, I_idx]), RowMaximum(); check=false), b)
+
+    x        = zeros(n)
+    x[I_idx] = x_interior
+    x[B_idx] = x_B
+
+    null_basis          = zeros(n, size(null_interior, 2))
     null_basis[I_idx,:] = null_interior
 
     return BlockArray(x, s.vertex_stalks), null_basis

--- a/src/network_sheaves/TrajectorySheaf.jl
+++ b/src/network_sheaves/TrajectorySheaf.jl
@@ -1003,7 +1003,7 @@ function optimal_control_trajectory(ts::ControlledTrajectorySheaf{T},
 
     # Step 3: Solve using ChordalLDLt pseudoinverse.
     Rred_sparse = sparse(Rred)
-    M_ldlt      = ldlt!(ChordalLDLt(Rred_sparse), RowMaximum())
+    M_ldlt      = ldlt!(ChordalLDLt(Rred_sparse), RowMaximum(); check=false)
 
     # Cheap convexity check: for a symmetric matrix, a negative LDL pivot
     # certifies that the reduced Hessian is not positive semidefinite.

--- a/test/network_sheaves/MultiAgentTrackingMPC.jl
+++ b/test/network_sheaves/MultiAgentTrackingMPC.jl
@@ -1,6 +1,7 @@
 using Test
 using CellularSheaves
 using CellularSheaves.ControlSheaves.MultiAgentTracking
+using CellularSheaves.TrajectorySheaves: continuous_to_discrete_zoh
 using LinearAlgebra
 using SparseArrays
 using BlockArrays
@@ -190,6 +191,63 @@ using BlockArrays
                                        window=4, cost=1.0, solver=:naive)
         for i in 1:n_agents
             @test res_default.agent_trajs[i] ≈ res_naive.agent_trajs[i] atol=1e-10
+        end
+    end
+
+    @testset "run_mpc_scenario — cached and naive agree on planar-quadrotor docs scenario" begin
+        g = 9.81
+        m_veh = 0.5
+        I_quad = 0.01
+        ell = 0.25
+
+        Ac = [0.0  0.0   0.0   1.0  0.0  0.0;
+              0.0  0.0   0.0   0.0  1.0  0.0;
+              0.0  0.0   0.0   0.0  0.0  1.0;
+              0.0  0.0  -g     0.0  0.0  0.0;
+              0.0  0.0   0.0   0.0  0.0  0.0;
+              0.0  0.0   0.0   0.0  0.0  0.0]
+        Bc = [0.0               0.0;
+              0.0               0.0;
+              0.0               0.0;
+              0.0               0.0;
+              1.0 / m_veh       1.0 / m_veh;
+              ell / (2I_quad)  -ell / (2I_quad)]
+
+        hq = 0.05
+        Adq, Bdq = continuous_to_discrete_zoh(Ac, Bc, hq)
+        nxq, nuq = size(Adq, 1), size(Bdq, 2)
+        kq = 12
+        timesq = hq .* collect(0:kq)
+        idx_y, idx_z, idx_zdt = 1, 2, 5
+        R_yz_q = state_projection_matrix([idx_y, idx_z], nxq, nuq)
+
+        omega = 2π * 2 / (kq * hq)
+        target_trajs_q = [
+            trajectory(BobbingTarget(-0.35, 1.2,  0.30, omega), 0:kq, hq, nxq, nuq, idx_y, idx_z, idx_zdt),
+            trajectory(BobbingTarget( 0.35, 1.8, -0.30, omega), 0:kq, hq, nxq, nuq, idx_y, idx_z, idx_zdt),
+        ]
+        prob_q = TrackingProblem(
+            2, 2, kq,
+            [Adq, Adq], [Bdq, Bdq], [Adq, Adq], [Bdq, Bdq],
+            Tuple{Int,Int}[],
+            [TrackingEdge(1, 1, R_yz_q, R_yz_q), TrackingEdge(2, 2, R_yz_q, R_yz_q)],
+            R_yz_q,
+            Int[], collect(0:kq),
+            false, 0.0, 5.0,
+        )
+        x0_q = [[0.0, 0.35, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.35, 0.0, 0.0, 0.0, 0.0]]
+
+        for W in (2, 6, kq)
+            res_cached = run_mpc_scenario("cached", prob_q, x0_q, target_trajs_q, timesq;
+                                          window=W, cost=1.0, solver=:cached)
+            res_naive = run_mpc_scenario("naive", prob_q, x0_q, target_trajs_q, timesq;
+                                         window=W, cost=1.0, solver=:naive)
+            @test res_cached.null_dim == res_naive.null_dim
+            @test res_cached.residual ≈ res_naive.residual atol=1e-6
+            for i in 1:2
+                @test res_cached.agent_trajs[i] ≈ res_naive.agent_trajs[i] atol=1e-5
+            end
         end
     end
 

--- a/test/network_sheaves/MultiAgentTrackingMPC.jl
+++ b/test/network_sheaves/MultiAgentTrackingMPC.jl
@@ -46,9 +46,10 @@ using BlockArrays
         @test all(i -> size(result.agent_trajs[i]) == (k + 1, nx), 1:n_agents)
         @test length(result.target_trajs) == n_targets
         @test result.residual >= 0.0
-        # null_dim is the interior-nullspace dimension of the planning window
-        # (free coordination DOFs after pinning agent initials + targets).
-        @test result.null_dim == 2
+        # null_dim is the interior-nullspace dimension of the planning window.
+        # The reindexed window sheaf has no dangling terminal control, so with
+        # this fixture the cost fully determines the interior (null_dim == 0).
+        @test result.null_dim == 0
     end
 
     @testset "run_mpc_scenario — initial states equal x0_agents" begin
@@ -110,6 +111,16 @@ using BlockArrays
             "bad", prob, x0_agents, target_trajs, times; window=k, solver=:bogus)
     end
 
+    @testset "run_mpc_scenario — bad initial/target dimensions throw ArgumentError" begin
+        # Wrong agent initial-state length (nx=2 expected).
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, [[0.0], x0_agents[2]], target_trajs, times; window=k)
+        # Wrong target stalk length (target stalk is nx+nu=3 here).
+        bad_targets = [target_trajs[1], [Float64[0.0, 0.0] for _ in 0:k]]
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, x0_agents, bad_targets, times; window=k)
+    end
+
     @testset "run_mpc_scenario — cached and naive agree (homogeneous problem)" begin
         for W in (1, 3, k)
             res_c = run_mpc_scenario("c", prob, x0_agents, target_trajs, times;
@@ -129,7 +140,7 @@ using BlockArrays
         @test length(op.boundary) + length(op.interior) == n_tot
         @test size(op.M) == (length(op.interior), length(op.boundary))
         @test op.window == k
-        @test op.null_dim == 2
+        @test op.null_dim == 0
 
         x_B = randn(length(op.boundary))
         z = op(x_B)

--- a/test/network_sheaves/MultiAgentTrackingMPC.jl
+++ b/test/network_sheaves/MultiAgentTrackingMPC.jl
@@ -2,6 +2,7 @@ using Test
 using CellularSheaves
 using CellularSheaves.ControlSheaves.MultiAgentTracking
 using LinearAlgebra
+using SparseArrays
 using BlockArrays
 
 @testset "MultiAgentTrackingMPC" begin
@@ -141,6 +142,15 @@ using BlockArrays
         L_IB = op.laplacian[op.interior, op.boundary]
         g = L_II * z[op.interior] + L_IB * x_B
         @test norm(L_II * g) < 1e-6
+    end
+
+    @testset "tracking_extension_operator — Laplacian blocks stay sparse" begin
+        op = tracking_extension_operator(prob; cost=1.0)
+        @test op.laplacian isa SparseMatrixCSC
+        # Indexing the sparse Laplacian with index vectors must keep the blocks
+        # sparse (the operator build relies on this instead of converting).
+        @test op.laplacian[op.interior, op.interior] isa SparseMatrixCSC
+        @test op.laplacian[op.interior, op.boundary] isa SparseMatrixCSC
     end
 
     @testset "run_mpc_scenario — solver=:naive default-equivalent on inhomogeneous problem" begin

--- a/test/network_sheaves/MultiAgentTrackingMPC.jl
+++ b/test/network_sheaves/MultiAgentTrackingMPC.jl
@@ -164,6 +164,16 @@ using BlockArrays
         @test op.laplacian[op.interior, op.boundary] isa SparseMatrixCSC
     end
 
+    @testset "WindowSolverCache — mul! matches the call form" begin
+        op  = tracking_extension_operator(prob; cost=1.0)
+        x_B = randn(length(op.boundary))
+        z   = Vector{Float64}(undef, sum(op.stalks))
+        mul!(z, op, x_B)
+        @test z ≈ op(x_B)
+        @test z[op.boundary] ≈ x_B
+        @test_throws Exception mul!(zeros(sum(op.stalks) + 1), op, x_B)
+    end
+
     @testset "run_mpc_scenario — solver=:naive default-equivalent on inhomogeneous problem" begin
         # Tracking active only at the terminal step → not time-homogeneous, so the
         # cached default must transparently fall back to the naive path.

--- a/test/network_sheaves/MultiAgentTrackingMPC.jl
+++ b/test/network_sheaves/MultiAgentTrackingMPC.jl
@@ -1,0 +1,165 @@
+using Test
+using CellularSheaves
+using CellularSheaves.ControlSheaves.MultiAgentTracking
+using LinearAlgebra
+using BlockArrays
+
+@testset "MultiAgentTrackingMPC" begin
+
+    # Fixture mirrors MultiAgentTracking.jl: same dynamics, same projection
+    # matrices, same edge topology — horizon extended to k=8 for MPC tests.
+    nx = 2; nu = 1
+    Ad = Matrix{Float64}(I, nx, nx)
+    Bd = [0.0; 1.0;;]   # nx × nu
+
+    k         = 8
+    n_agents  = 2
+    n_targets = 2
+
+    R_full = state_projection_matrix([1, 2], nx, nu)
+    R1     = state_projection_matrix([1],    nx, nu)
+
+    te_full = [TrackingEdge(1, 1, R_full, R_full), TrackingEdge(2, 2, R_full, R_full)]
+
+    prob = TrackingProblem(
+        n_agents, n_targets, k,
+        [Ad, Ad], [Bd, Bd], [Ad, Ad], [Bd, Bd],
+        [(1, 2)], te_full, R_full,
+        collect(0:k), collect(0:k),
+        false, 0.5, 1.0,
+    )
+
+    x0_agents    = [[0.0, 0.0], [1.0, 0.0]]
+    target_trajs = [
+        [Float64[0.0, Float64(t),     0.0] for t in 0:k],
+        [Float64[1.0, Float64(k - t), 0.0] for t in 0:k],
+    ]
+    times = Float64.(0:k)
+
+    @testset "run_mpc_scenario — returns ScenarioResult with correct dimensions" begin
+        result = run_mpc_scenario("t1", prob, x0_agents, target_trajs, times; window=k)
+        @test result isa ScenarioResult
+        @test result.label == "t1"
+        @test length(result.times) == k + 1
+        @test length(result.agent_trajs) == n_agents
+        @test all(i -> size(result.agent_trajs[i]) == (k + 1, nx), 1:n_agents)
+        @test length(result.target_trajs) == n_targets
+        @test result.residual >= 0.0
+        # null_dim is the interior-nullspace dimension of the planning window
+        # (free coordination DOFs after pinning agent initials + targets).
+        @test result.null_dim == 2
+    end
+
+    @testset "run_mpc_scenario — initial states equal x0_agents" begin
+        result = run_mpc_scenario("t2", prob, x0_agents, target_trajs, times; window=k)
+        for i in 1:n_agents
+            @test result.agent_trajs[i][1, :] ≈ x0_agents[i]
+        end
+    end
+
+    @testset "run_mpc_scenario — all states remain finite" begin
+        result = run_mpc_scenario("t3", prob, x0_agents, target_trajs, times; window=k, cost=1.0)
+        for i in 1:n_agents
+            @test all(isfinite, result.agent_trajs[i])
+        end
+    end
+
+    @testset "run_mpc_scenario — window=1 greedy MPC runs without error" begin
+        result = run_mpc_scenario("t4", prob, x0_agents, target_trajs, times; window=1)
+        @test result isa ScenarioResult
+        @test length(result.times) == k + 1
+        @test all(i -> size(result.agent_trajs[i]) == (k + 1, nx), 1:n_agents)
+    end
+
+    @testset "run_mpc_scenario — window=k consistent with open-loop on constant target" begin
+        # When the target is constant at x0 the optimal control is u=0 for all t.
+        # Open-loop forces u_0=0 via the whole-stalk pin, which is also optimal here,
+        # so both methods find the same section and must agree exactly.
+        prob_const = TrackingProblem(
+            1, 1, k, [Ad], [Bd], [Ad], [Bd],
+            Tuple{Int,Int}[], [TrackingEdge(1, 1, R_full, R_full)],
+            R_full, Int[], collect(0:k),
+            false, 0.0, 1.0,
+        )
+        x0        = [0.0, 0.0]
+        const_tgt = [Float64[0.0, 0.0, 0.0] for _ in 0:k]
+
+        bnd = Dict{Int,Vector{Float64}}()
+        bnd[agent_vertex(prob_const, 1, 0)] = vcat(x0, zeros(nu))
+        for t in 0:k
+            bnd[target_vertex(prob_const, 1, t)] = const_tgt[t + 1]
+        end
+        result_ol  = run_scenario("ol",  prob_const, bnd,       times; cost=1.0)
+        result_mpc = run_mpc_scenario("mpc", prob_const, [x0], [const_tgt], times; window=k, cost=1.0)
+
+        @test result_ol.agent_trajs[1] ≈ result_mpc.agent_trajs[1] atol=1e-10
+        @test result_ol.residual       ≈ result_mpc.residual        atol=1e-10
+    end
+
+    @testset "run_mpc_scenario — bad arguments throw ArgumentError" begin
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, x0_agents, target_trajs, times; window=0)
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, [x0_agents[1]], target_trajs, times; window=k)
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, x0_agents, [target_trajs[1]], times; window=k)
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, x0_agents, target_trajs, Float64.(0:k+1); window=k)
+        @test_throws ArgumentError run_mpc_scenario(
+            "bad", prob, x0_agents, target_trajs, times; window=k, solver=:bogus)
+    end
+
+    @testset "run_mpc_scenario — cached and naive agree (homogeneous problem)" begin
+        for W in (1, 3, k)
+            res_c = run_mpc_scenario("c", prob, x0_agents, target_trajs, times;
+                                     window=W, cost=1.0, solver=:cached)
+            res_n = run_mpc_scenario("n", prob, x0_agents, target_trajs, times;
+                                     window=W, cost=1.0, solver=:naive)
+            @test res_c.null_dim == res_n.null_dim
+            for i in 1:n_agents
+                @test res_c.agent_trajs[i] ≈ res_n.agent_trajs[i] atol=1e-6
+            end
+        end
+    end
+
+    @testset "tracking_extension_operator — pinning and harmonic stationarity" begin
+        op = tracking_extension_operator(prob; cost=1.0)
+        n_tot = sum(op.stalks)
+        @test length(op.boundary) + length(op.interior) == n_tot
+        @test size(op.M) == (length(op.interior), length(op.boundary))
+        @test op.window == k
+        @test op.null_dim == 2
+
+        x_B = randn(length(op.boundary))
+        z = op(x_B)
+        @test length(z) == n_tot
+        # Boundary is pinned exactly.
+        @test z[op.boundary] ≈ x_B
+        # Interior is the harmonic extension: the interior energy gradient
+        # g = L_II z_I + L_IB z_B lies in ker(L_II), so L_II * g ≈ 0.
+        L_II = op.laplacian[op.interior, op.interior]
+        L_IB = op.laplacian[op.interior, op.boundary]
+        g = L_II * z[op.interior] + L_IB * x_B
+        @test norm(L_II * g) < 1e-6
+    end
+
+    @testset "run_mpc_scenario — solver=:naive default-equivalent on inhomogeneous problem" begin
+        # Tracking active only at the terminal step → not time-homogeneous, so the
+        # cached default must transparently fall back to the naive path.
+        prob_inhom = TrackingProblem(
+            n_agents, n_targets, k,
+            [Ad, Ad], [Bd, Bd], [Ad, Ad], [Bd, Bd],
+            [(1, 2)], te_full, R_full,
+            Int[], [k],
+            false, 0.5, 1.0,
+        )
+        res_default = run_mpc_scenario("d", prob_inhom, x0_agents, target_trajs, times;
+                                       window=4, cost=1.0)
+        res_naive   = run_mpc_scenario("n", prob_inhom, x0_agents, target_trajs, times;
+                                       window=4, cost=1.0, solver=:naive)
+        for i in 1:n_agents
+            @test res_default.agent_trajs[i] ≈ res_naive.agent_trajs[i] atol=1e-10
+        end
+    end
+
+end

--- a/test/network_sheaves/QuadraticCosts.jl
+++ b/test/network_sheaves/QuadraticCosts.jl
@@ -30,9 +30,11 @@ end
 
 @testset "QuadraticCost utilities" begin
     prob = make_simple_prob(k=2, nx=2, nu=2, control_weight=2.0)
+    # Stalk layout of the (default) time-expanded sheaf: nx+nu per agent vertex.
+    stalks = [size(prob.Ad[1],1) + size(prob.Bd[1],2) for _ in 0:prob.k]
     # Build Q with simple 2-norm weight (2.0 * I)
-    Q = build_control_cost_matrix(prob, 2.0)
-    total_dim = sum([ (size(prob.Ad[1],1)+size(prob.Bd[1],2)) for _ in 0:prob.k ])
+    Q = build_control_cost_matrix(prob, stalks, 2.0)
+    total_dim = sum(stalks)
     @test size(Q) == (total_dim, total_dim)
     # Expected control indices for each time step
     control_idxs = Int[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ end
   include("network_sheaves/NullspaceTrajectoryFamily.jl")
   include("network_sheaves/ControlledTrajectoryExamples.jl")
   include("network_sheaves/MultiAgentTracking.jl")
+  include("network_sheaves/MultiAgentTrackingMPC.jl")
   include("network_sheaves/per_agent_and_target_dynamics.jl")
   include("network_sheaves/TrackingDSL.jl")
   include("network_sheaves/QuadraticCosts.jl")


### PR DESCRIPTION
This PR implements a receding-horizon MPC algorithm for multi-agent tracking sheaf problems. 

### Summary

- Added `window_problem` to take the entire horizon and slice it up into sub problems of size `k`.
- Added pre-computation of sheaf Laplacian factorization, which turns each MPC step from resolving the open loop problem on a smaller horizon to a simple solve of the harmonic extension.
- Added `run_mpc_scenario` with `:cached` (reuses the factorization + orthogonal projection) & `:naive` (recomputes the open loop problem for each MPC step)
- Added `ldlt_pinv_solve` helpers to `EuclideanSheaves` and switched `solve_quadratic_on_basis` to use `svd\`

### Tests
- 40 new tests in `test/network_sheaves/MultiAgentTrackingMPC.jl`.

### Docs
- New literate page in `docs/literature/control/mpc_target_tracking.jl` showcasing the results of this PR and the application of the algorithm in different scenarios. 

Closes #62